### PR TITLE
Adds Basic OAuth2 Client Name / Address Masking

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,6 +58,8 @@ export default {
 
     this.initializeApi()
 
+    this.$store.dispatch('updateOAuth2Clients')
+
     this.$store.dispatch('registerWeb3', this.$router)
       .then(() => {
 

--- a/src/components/RecordProvenance.vue
+++ b/src/components/RecordProvenance.vue
@@ -88,18 +88,25 @@ export default {
       }
     },
     getEventAddress(row) {
+
+      let address = null
+
       switch (row.type) {
         case 'created':
         case 'destroyed':
         case 'transferred':
-          return row.newOwnerAddress
+          address = row.newOwnerAddress
+          break
 
         case 'modified':
-          return row.codexRecordModifiedEvent.modifierAddress
+          address = row.codexRecordModifiedEvent.modifierAddress
+          break
 
-        default:
-          return null
+        default: // do nothing
       }
+
+      return this.$store.getters.getOAuth2ClientNameFromAddress(address)
+
     },
     getTransactionUrl(txHash) {
       return etherscanHelper.getTxUrl(txHash)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex'
 
 import auth from './modules/auth'
 import web3 from './modules/web3'
+import oauth2 from './modules/oauth2'
 
 Vue.use(Vuex)
 
@@ -11,6 +12,7 @@ const debug = process.env.NODE_ENV !== 'production'
 export default new Vuex.Store({
   strict: debug,
   modules: {
+    oauth2,
     auth,
     web3,
   },

--- a/src/store/modules/oauth2.js
+++ b/src/store/modules/oauth2.js
@@ -1,0 +1,64 @@
+import axios from 'axios'
+import Raven from 'raven-js'
+
+const getInitialState = () => {
+  return {
+    clients: null,
+    clientNameMap: null,
+  }
+}
+
+const getters = {
+  getOAuth2ClientNameFromAddress(currentState) {
+    return (address, includeCheckmark = false) => {
+      const name = currentState.clientNameMap[address]
+
+      if (!name) {
+        return address
+      }
+
+      return `${includeCheckmark ? '✅ ' : ''}${currentState.clientNameMap[address]}`
+
+    }
+  },
+}
+
+const actions = {
+  updateOAuth2Clients({ commit }) {
+
+    const requestOptions = {
+      url: '/oauth2/clients',
+      method: 'get',
+    }
+
+    return axios(requestOptions)
+      .then((response) => {
+        commit('setOAuth2Clients', response.data.result)
+      })
+      .catch((error) => {
+        Raven.captureException(error)
+      })
+  },
+
+}
+
+const mutations = {
+  setOAuth2Clients(currentState, newOAuth2Clients) {
+
+    const newClientNameMap = {}
+
+    newOAuth2Clients.forEach((oAuth2Client) => {
+      newClientNameMap[oAuth2Client.user.address] = oAuth2Client.user.name
+    })
+
+    currentState.oAuth2Clients = newOAuth2Clients
+    currentState.clientNameMap = newClientNameMap
+  },
+}
+
+export default {
+  getters,
+  actions,
+  mutations,
+  state: getInitialState(),
+}


### PR DESCRIPTION
A lot of this implementation will likely change, but here's the basic concept.

![screen shot 2018-08-24 at 2 27 27 pm](https://user-images.githubusercontent.com/2358694/44604065-5ceb3f00-a7aa-11e8-91c4-eaef140f16b2.png)

The address masking should probably happen anywhere we show an address (which I think right now is really only the provenance and transfer pages?)