### PR TITLE
Progress bar for gas allowance

### DIFF
--- a/src/assets/variables.styl
+++ b/src/assets/variables.styl
@@ -25,7 +25,7 @@ $breakpoint-lg = 992px
 $breakpoint-xl = 1200px
 
 // Dimensions
-$side-nav-width = 14rem
+$side-nav-width = 15rem
 $bottom-nav-height = 4rem
 
 card()

--- a/src/components/PrepaidTransactionsControl.vue
+++ b/src/components/PrepaidTransactionsControl.vue
@@ -3,11 +3,11 @@
     <div><b>Prepaid Transactions</b></div>
     <b-progress
       class="progress-container"
-      :max="parseInt(user.maxGasAllowance, 10)"
+      :max="parseInt(user.gasAllowance, 10)"
     >
       <b-progress-bar
         class="progress-bar"
-        :value="parseInt(user.gasAllowance, 10)"
+        :value="parseInt(user.gasAllowanceRemaining, 10)"
         :variant="variant"
       />
     </b-progress>
@@ -29,7 +29,7 @@ export default {
 
     variant() {
       const percentageRemaining =
-        ((parseInt(this.user.gasAllowance, 10) / this.user.maxGasAllowance) * 100).toFixed(0)
+        ((parseInt(this.user.gasAllowanceRemaining, 10) / this.user.gasAllowance) * 100).toFixed(0)
 
       if (percentageRemaining < 15) {
         return 'danger'

--- a/src/components/PrepaidTransactionsControl.vue
+++ b/src/components/PrepaidTransactionsControl.vue
@@ -19,6 +19,7 @@ import {
   mapState,
   mapGetters,
 } from 'vuex'
+import BigNumber from 'bignumber.js'
 
 export default {
   name: 'PrepaidTransactionsControl',
@@ -28,8 +29,10 @@ export default {
     ...mapGetters('auth', ['isSimpleUser']),
 
     variant() {
-      const percentageRemaining =
-        ((parseInt(this.user.gasAllowanceRemaining, 10) / this.user.gasAllowance) * 100).toFixed(0)
+      const percentageRemaining = new BigNumber(this.user.gasAllowanceRemaining)
+        .div(this.user.gasAllowance)
+        .mul(100)
+        .toFixed(0)
 
       if (percentageRemaining < 15) {
         return 'danger'

--- a/src/components/PrepaidTransactionsControl.vue
+++ b/src/components/PrepaidTransactionsControl.vue
@@ -3,11 +3,11 @@
     <div><b>Prepaid Transactions</b></div>
     <b-progress
       class="progress-container"
-      :max="max"
+      :max="parseInt(user.maxGasAllowance, 10)"
     >
       <b-progress-bar
         class="progress-bar"
-        :value="parseInt(user.gasAllowance)"
+        :value="parseInt(user.gasAllowance, 10)"
         :variant="variant"
       />
     </b-progress>
@@ -23,19 +23,13 @@ import {
 export default {
   name: 'PrepaidTransactionsControl',
 
-  data() {
-    return {
-      // @todo: replace with gasMaxAllowance when it's ready
-      max: 4050000,
-    }
-  },
-
   computed: {
     ...mapState('auth', ['user']),
     ...mapGetters('auth', ['isSimpleUser']),
 
     variant() {
-      const percentageRemaining = ((parseInt(this.user.gasAllowance, 10) / this.max) * 100).toFixed(0)
+      const percentageRemaining =
+        ((parseInt(this.user.gasAllowance, 10) / this.user.maxGasAllowance) * 100).toFixed(0)
 
       if (percentageRemaining < 15) {
         return 'danger'
@@ -56,6 +50,7 @@ export default {
 
 .allowance-container
   text-align: center
+  width: 100%
 
 .progress-container
   background-color: rgba(white, .2)

--- a/src/components/PrepaidTransactionsControl.vue
+++ b/src/components/PrepaidTransactionsControl.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="allowance-container" v-if="isSimpleUser">
+    <div><b>Prepaid Transactions</b></div>
+    <b-progress
+      class="progress-container"
+      :max="max"
+    >
+      <b-progress-bar
+        class="progress-bar"
+        :value="parseInt(user.gasAllowance)"
+        :variant="variant"
+      />
+    </b-progress>
+  </div>
+</template>
+
+<script>
+import {
+  mapState,
+  mapGetters,
+} from 'vuex'
+
+export default {
+  name: 'PrepaidTransactionsControl',
+
+  data() {
+    return {
+      // @todo: replace with gasMaxAllowance when it's ready
+      max: 4050000,
+    }
+  },
+
+  computed: {
+    ...mapState('auth', ['user']),
+    ...mapGetters('auth', ['isSimpleUser']),
+
+    variant() {
+      const percentageRemaining = ((parseInt(this.user.gasAllowance, 10) / this.max) * 100).toFixed(0)
+
+      if (percentageRemaining < 15) {
+        return 'danger'
+      }
+
+      if (percentageRemaining < 35) {
+        return 'warning'
+      }
+
+      return 'success'
+    },
+  },
+}
+</script>
+
+<style lang="stylus" scoped>
+@import "../assets/variables.styl"
+
+.allowance-container
+  text-align: center
+
+.progress-container
+  background-color: rgba(white, .2)
+  height: 2rem
+  margin: 0.5rem
+
+.progress-bar
+  color: black
+  font-weight: bold
+  margin: 0.5rem
+</style>

--- a/src/components/cards/CreateRecordCard.vue
+++ b/src/components/cards/CreateRecordCard.vue
@@ -17,17 +17,6 @@
 <script>
 export default {
   name: 'CreateRecordCard',
-
-  data() {
-    return {
-    }
-  },
-
-  computed: {
-  },
-
-  methods: {
-  },
 }
 </script>
 
@@ -37,11 +26,10 @@ export default {
 .faucet-card
   card()
   width: 100%
-  min-width: 180px
+  min-width: 320px
 
 .card
   height: 100%
-  margin: 0
   border: none
   background-color: rgba(white, .1)
 

--- a/src/components/core/AppSideBar.vue
+++ b/src/components/core/AppSideBar.vue
@@ -189,9 +189,8 @@ export default {
 @import "../../assets/variables.styl"
 
 hr
-  width: 90%
   border-top: 1px solid rgba($color-light, .5)
-  margin-bottom: 0
+  margin: 1rem 1rem 0
 
 nav
   display: none

--- a/src/components/core/AppSideBar.vue
+++ b/src/components/core/AppSideBar.vue
@@ -19,9 +19,11 @@
           {{ numberOfIncomingTransfers }}
         </b-badge>
       </b-link>
+      <hr />
       <div class="contact" v-if="user">
         Logged in as <DisplayName :userObject="user" />
       </div>
+      <PrepaidTransactionsControl />
     </div>
   </nav>
 </template>
@@ -33,6 +35,8 @@ import {
 } from 'vuex'
 
 import DisplayName from '../util/DisplayName'
+import PrepaidTransactionsControl from '../PrepaidTransactionsControl'
+
 import Transfer from '../../util/api/transfer'
 import EventBus from '../../util/eventBus'
 import config from '../../util/config'
@@ -54,6 +58,7 @@ export default {
 
   components: {
     DisplayName,
+    PrepaidTransactionsControl,
   },
 
   data() {
@@ -182,6 +187,11 @@ export default {
 
 <style lang="stylus" scoped>
 @import "../../assets/variables.styl"
+
+hr
+  width: 90%
+  border-top: 1px solid rgba($color-light, .5)
+  margin-bottom: 0
 
 nav
   display: none

--- a/src/components/util/DisplayName.vue
+++ b/src/components/util/DisplayName.vue
@@ -34,7 +34,8 @@ export default {
     ...mapGetters('oauth2', ['getOAuth2ClientNameFromAddress']),
 
     processedName() {
-      if (this.user && this.selectedName === this.user.address) {
+      // If userObject is defined, show the full selected name instead of 'You'
+      if (this.user && !this.userObject && this.selectedName === this.user.address) {
         return 'You'
       }
 

--- a/src/store/modules/auth/mutations.js
+++ b/src/store/modules/auth/mutations.js
@@ -99,9 +99,9 @@ export default {
   SPEND_GAS(currentState, { estimatedGas }) {
     logMutation('SPEND_GAS', estimatedGas)
 
-    if (currentState.user && currentState.user.gasAllowance) {
-      const bnAllowance = new BigNumber(currentState.user.gasAllowance)
-      currentState.user.gasAllowance = bnAllowance.sub(estimatedGas).toString()
+    if (currentState.user && currentState.user.gasAllowanceRemaining) {
+      const bnAllowance = new BigNumber(currentState.user.gasAllowanceRemaining)
+      currentState.user.gasAllowanceRemaining = bnAllowance.sub(estimatedGas).toString()
     }
   },
 }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -77,6 +77,10 @@ export default {
         text: 'Remaining gas',
       },
       {
+        property: 'maxGasAllowance',
+        text: 'Prepaid gas per month',
+      },
+      {
         property: 'email',
         text: 'Email address',
       },

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -68,7 +68,7 @@ export default {
         formatter: formatDate,
       },
       {
-        property: 'allowanceLastResetAt',
+        property: 'gasAllowanceLastResetAt',
         text: 'Allowance reset',
         formatter: formatDate,
       },

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -73,11 +73,11 @@ export default {
         formatter: formatDate,
       },
       {
-        property: 'gasAllowance',
+        property: 'gasAllowanceRemaining',
         text: 'Remaining gas',
       },
       {
-        property: 'maxGasAllowance',
+        property: 'gasAllowance',
         text: 'Prepaid gas per month',
       },
       {


### PR DESCRIPTION
* Adds a progress bar for simple users that shows their remaining gas balance for the month
  * NOTE: This is only used in the side bar right now. I want to show raw numbers in the settings page (we may need to tweak the language at some point).
* Fixes some stylistic issues
* Fixes saying 'You' for savvy users in the side bar