### PR TITLE
Adds confirm-email route and associated "resend email" dialog

### DIFF
--- a/src/components/modals/ResendConfirmationEmailModal.vue
+++ b/src/components/modals/ResendConfirmationEmailModal.vue
@@ -24,8 +24,13 @@
 </template>
 
 <script>
+
+import debug from 'debug'
+
 import EventBus from '../../util/eventBus'
 import EmailConfirmation from '../../util/api/emailConfirmation'
+
+const logger = debug('app:component:resend-confirmation-email-modal')
 
 export default {
 
@@ -62,7 +67,8 @@ export default {
           this.modalVisible = false
         })
         .catch((error) => {
-          EventBus.$emit('toast:error', `Could not resend confirmation email: ${error.message}`)
+          logger('Could not resend confirmation email:', error)
+          EventBus.$emit('toast:error', 'Could not resend confirmation email.')
         })
     },
   },

--- a/src/components/modals/ResendConfirmationEmailModal.vue
+++ b/src/components/modals/ResendConfirmationEmailModal.vue
@@ -49,8 +49,6 @@ export default {
 
     resendConfirmationEmail(event) {
 
-      event.preventDefault()
-
       if (!this.emailAddress) {
         this.modalVisible = false
         return

--- a/src/components/modals/ResendConfirmationEmailModal.vue
+++ b/src/components/modals/ResendConfirmationEmailModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <b-modal
+    ok-title="Send"
+    @hidden="reset"
+    v-model="modalVisible"
+    cancel-variant="outline-primary"
+    id="resendConfirmationEmailModal"
+    title="Resend Confirmation Email"
+    v-on:ok="resendConfirmationEmail"
+  >
+    <b-form-group
+      label-size="sm"
+      label-for="emailAddress"
+      label="Email Address"
+    >
+      <b-form-input
+        required
+        class="mb-4"
+        id="emailAddress"
+        v-model="emailAddress"
+      />
+    </b-form-group>
+  </b-modal>
+</template>
+
+<script>
+import EventBus from '../../util/eventBus'
+import EmailConfirmation from '../../util/api/emailConfirmation'
+
+export default {
+
+  name: 'ResendConfirmationEmailModal',
+
+  props: {
+    email: String,
+  },
+
+  data() {
+    return {
+      modalVisible: false,
+      emailAddress: this.email,
+    }
+  },
+
+  methods: {
+    reset() {
+      this.emailAddress = this.email
+    },
+
+    resendConfirmationEmail(event) {
+
+      event.preventDefault()
+
+      if (!this.emailAddress) {
+        this.modalVisible = false
+        return
+      }
+
+      EventBus.$emit('events:resend-confirmation-email-dialog', this)
+
+      EmailConfirmation.resend(this.emailAddress)
+        .then(() => {
+          EventBus.$emit('toast:success', 'Confirmation email has been re-sent!', 5000)
+          this.modalVisible = false
+        })
+        .catch((error) => {
+          EventBus.$emit('toast:error', `Could not resend confirmation email: ${error.message}`)
+        })
+    },
+  },
+}
+</script>
+
+<style lang="stylus" scoped>
+
+.token-icon
+  width: 8rem
+  margin-bottom: 2rem
+
+</style>

--- a/src/components/modals/ResendConfirmationEmailModal.vue
+++ b/src/components/modals/ResendConfirmationEmailModal.vue
@@ -3,10 +3,10 @@
     ok-title="Send"
     @hidden="reset"
     v-model="modalVisible"
+    @ok="resendConfirmationEmail"
     cancel-variant="outline-primary"
     id="resendConfirmationEmailModal"
     title="Resend Confirmation Email"
-    v-on:ok="resendConfirmationEmail"
   >
     <b-form-group
       label-size="sm"

--- a/src/components/modals/ResendConfirmationEmailModal.vue
+++ b/src/components/modals/ResendConfirmationEmailModal.vue
@@ -3,10 +3,10 @@
     ok-title="Send"
     @hidden="reset"
     v-model="modalVisible"
-    @ok="resendConfirmationEmail"
     cancel-variant="outline-primary"
     id="resendConfirmationEmailModal"
     title="Resend Confirmation Email"
+    @ok="resendConfirmationEmail(emailAddress)"
   >
     <b-form-group
       label-size="sm"
@@ -37,31 +37,31 @@ export default {
   name: 'ResendConfirmationEmailModal',
 
   props: {
-    email: String,
+    defaultEmail: String,
   },
 
   data() {
     return {
       modalVisible: false,
-      emailAddress: this.email,
+      emailAddress: this.defaultEmail,
     }
   },
 
   methods: {
     reset() {
-      this.emailAddress = this.email
+      this.emailAddress = this.defaultEmail
     },
 
-    resendConfirmationEmail(event) {
+    resendConfirmationEmail(emailAddress) {
 
-      if (!this.emailAddress) {
-        this.modalVisible = false
+      if (!emailAddress) {
+        this.hide()
         return
       }
 
       EventBus.$emit('events:resend-confirmation-email-dialog', this)
 
-      EmailConfirmation.resend(this.emailAddress)
+      EmailConfirmation.resend(emailAddress)
         .then(() => {
           EventBus.$emit('toast:success', 'Confirmation email has been re-sent!', 5000)
           this.modalVisible = false

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,7 @@ import store from '../store'
 import config from '../util/config'
 
 import LoginView from '../views/LoginView'
+import ConfirmEmailView from '../views/ConfirmEmailView'
 import FeatureListView from '../views/FeatureListView'
 import TransferListView from '../views/TransferListView'
 import RecordListView from '../views/RecordListView'
@@ -27,6 +28,17 @@ const router = new Router({
       path: '/login',
       alias: '/',
       component: LoginView,
+      meta: {
+        hideSideBar: true,
+        useBackgroundImage: true,
+        allowUnauthenticatedUsers: true,
+        ifAuthenticatedRedirectTo: 'collection',
+      },
+    },
+    {
+      name: 'confirm-email',
+      path: '/confirm-email',
+      component: ConfirmEmailView,
       meta: {
         hideSideBar: true,
         useBackgroundImage: true,

--- a/src/util/analytics/eventNames.js
+++ b/src/util/analytics/eventNames.js
@@ -4,7 +4,9 @@
 const category = 'Codex Viewer'
 
 const actionsLabels = {
-  'events:viewer:view-login-page': {
+
+  // Login
+  'events:view-login-page': {
     action: 'View',
     label: 'Login Page',
   },
@@ -29,11 +31,23 @@ const actionsLabels = {
     label: 'Logout Button',
   },
 
+  // Confirmation Email
+  'events:view-confirm-email-page': {
+    action: 'View',
+    label: 'Confirm Email Page',
+  },
+  'events:resend-confirmation-email-dialog': {
+    action: 'Click',
+    label: 'Resend Confirmation Email',
+  },
+
+  // Collection
   'events:view-collection-page': {
     action: 'View',
     label: 'Collection Page',
   },
 
+  // Record
   'events:view-record-page': {
     action: 'View',
     label: 'Record Page',
@@ -47,6 +61,7 @@ const actionsLabels = {
     label: 'Record Transfer',
   },
 
+  // Transfer
   'events:view-transfers-page': {
     action: 'View',
     label: 'Transfers Page',
@@ -68,11 +83,13 @@ const actionsLabels = {
     label: 'Cancel Transfer',
   },
 
+  // Settings
   'events:view-settings-page': {
     action: 'View',
     label: 'Settings Page',
   },
 
+  // Manage Tokens
   'events:view-tokens-page': {
     action: 'View',
     label: 'Tokens Page',
@@ -106,6 +123,7 @@ const actionsLabels = {
     label: 'Unstake Tokens',
   },
 
+  // Coming Soon
   'events:view-coming-soon-page': {
     action: 'View',
     label: 'Coming Soon Page',
@@ -114,10 +132,14 @@ const actionsLabels = {
     action: 'Click',
     label: 'Partner Link',
   },
+
+  // Gallery
   'events:view-gallery-page': {
     action: 'View',
     label: 'Gallery Page',
   },
+
+  // Faucet
   'events:view-faucet-page': {
     action: 'View',
     label: 'Faucet Page',

--- a/src/util/analytics/events.js
+++ b/src/util/analytics/events.js
@@ -16,7 +16,6 @@ const events = (analytics) => {
   }
 
   Object.keys(actionsLabels).forEach((actionsLabel) => {
-    console.log('actionsLabel', actionsLabel)
     registerEvent(actionsLabel)
   })
 

--- a/src/util/analytics/events.js
+++ b/src/util/analytics/events.js
@@ -15,53 +15,11 @@ const events = (analytics) => {
     })
   }
 
-  // @NOTE: Registering a new event below requires adding the event to `./eventNames.js`
+  Object.keys(actionsLabels).forEach((actionsLabel) => {
+    console.log('actionsLabel', actionsLabel)
+    registerEvent(actionsLabel)
+  })
 
-  // Login
-  registerEvent('events:viewer:view-login-page')
-  registerEvent('events:click-login-button')
-  registerEvent('events:click-install-metamask')
-  registerEvent('events:click-check-metamask')
-  registerEvent('events:login')
-  registerEvent('events:click-logout-button')
-
-  // Collection
-  registerEvent('events:view-collection-page')
-
-  // Record
-  registerEvent('events:view-record-page')
-  registerEvent('events:record-click-transfer')
-  registerEvent('events:record-transfer')
-
-  // Transfers
-  registerEvent('events:view-transfers-page')
-  registerEvent('events:click-accept-transfer')
-  registerEvent('events:accept-transfer')
-  registerEvent('events:click-cancel-transfer')
-  registerEvent('events:cancel-transfer')
-
-  // Settings
-  registerEvent('events:view-settings-page')
-
-  // Manage Tokens
-  registerEvent('events:view-tokens-page')
-  registerEvent('events:click-approve-contract')
-  registerEvent('events:approve-contract')
-  registerEvent('events:faucet-request')
-  registerEvent('events:click-stake-tokens')
-  registerEvent('events:stake-tokens')
-  registerEvent('events:click-unstake-tokens')
-  registerEvent('events:unstake-tokens')
-
-  // Coming Soon
-  registerEvent('events:view-coming-soon-page')
-  registerEvent('events:click-partner-link')
-
-  // Gallery
-  registerEvent('events:view-gallery-page')
-
-  // Faucet
-  registerEvent('events:view-faucet-page')
 }
 
 export default events

--- a/src/util/api/emailConfirmation.js
+++ b/src/util/api/emailConfirmation.js
@@ -1,0 +1,15 @@
+import callApi from './callApi'
+
+export default {
+  resend: (email) => {
+    const requestOptions = {
+      method: 'post',
+      url: '/email-confirmation/resend',
+      data: {
+        email,
+      },
+    }
+
+    return callApi(requestOptions)
+  },
+}

--- a/src/views/ConfirmEmailView.vue
+++ b/src/views/ConfirmEmailView.vue
@@ -20,7 +20,7 @@
           {{ buttonText }}
         </b-button>
 
-        <ResendConfirmationEmailModal :email="this.emailAddress" />
+        <ResendConfirmationEmailModal :default-email="this.emailAddress" />
 
       </div>
       <div class="col-12 col-md-6 secondary">

--- a/src/views/ConfirmEmailView.vue
+++ b/src/views/ConfirmEmailView.vue
@@ -59,7 +59,7 @@ export default {
 
   created() {
 
-    EventBus.$emit('events:viewer:confirm-email-page', this)
+    EventBus.$emit('events:view-confirm-email-page', this)
 
     // remove email from the query params if specified
     if (this.$route.query.email) {

--- a/src/views/ConfirmEmailView.vue
+++ b/src/views/ConfirmEmailView.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12 col-md-6 primary">
+        <div class="logo">
+          <b-link href="/" replace>
+            <img src="../assets/logos/codex/gold.svg" />
+          </b-link>
+        </div>
+
+        <h1>{{ headerText }}</h1>
+        <div class="lead">{{ bodyText }}</div>
+
+        <b-button
+          size="sm"
+          variant="link"
+          class="pl-0 pr-0"
+          v-b-modal.resendConfirmationEmailModal
+        >
+          {{ buttonText }}
+        </b-button>
+
+        <ResendConfirmationEmailModal :email="this.emailAddress" />
+
+      </div>
+      <div class="col-12 col-md-6 secondary">
+        <div class="login-art"><img src="../assets/images/login-art.png" /></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+import EventBus from '../util/eventBus'
+import ResendConfirmationEmailModal from '../components/modals/ResendConfirmationEmailModal'
+
+export default {
+
+  name: 'ConfirmEmailView',
+
+  components: {
+    ResendConfirmationEmailModal,
+  },
+
+  data() {
+    return {
+      emailAddress: null,
+      headerText: 'Confirm Your Email Address',
+      buttonText: 'Didn\'t receive a confirmation email?',
+      bodyText: 'Please check your email for a confirmation link from Codex Protocol. Once your email is confirmed, you\'ll automatically be logged into the Codex Registry.',
+    }
+  },
+
+  computed: {
+    ...mapState('auth', ['apiError']),
+  },
+
+  created() {
+
+    EventBus.$emit('events:viewer:confirm-email-page', this)
+
+    // remove email from the query params if specified
+    if (this.$route.query.email) {
+      this.emailAddress = this.$route.query.email
+      this.$router.replace({ name: this.$route.name })
+    }
+
+  },
+
+  mounted() {
+    if (this.apiError) {
+      this.buttonText = 'Resend Confirmation Email?'
+      this.headerText = 'Could Not Confirm Your Email Address'
+      this.bodyText = 'There was an error while confirming your email address.'
+    }
+  },
+}
+</script>
+
+<style lang="stylus" scoped>
+
+@import "../assets/variables.styl"
+
+.logo
+  max-width: 100px
+  margin-bottom: 2.5rem
+  margin-top: 2.5rem
+
+h1
+  font-weight: bold
+  font-family: $font-family-serif
+
+.lead
+  margin-bottom: 3rem
+
+.login-art img
+  width: 100%
+  margin-top: 3rem
+
+</style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -55,7 +55,7 @@ export default {
   },
 
   created() {
-    EventBus.$emit('events:viewer:view-login-page', this)
+    EventBus.$emit('events:view-login-page', this)
   },
 
   computed: {


### PR DESCRIPTION
This PR adds a new route that the functionality introduced in [API PR #21](https://github.com/codex-protocol/private-service.codex-registry-api/pull/21) will use to complete the "confirm email" flow.