### PR TITLE
Style MMNM Form Errors

### DIFF
--- a/src/components/modals/MetaMaskNotificationModal.vue
+++ b/src/components/modals/MetaMaskNotificationModal.vue
@@ -28,10 +28,12 @@
     -->
     <div v-show="shouldShowMainSlot">
       <p v-if="errors.length">
-        <span>Please fix these error(s):</span>
-        <ul>
-          <li v-for="(error, index) in errors" :key="index">{{ error }}</li>
-        </ul>
+        <b-alert variant="danger" :show="errors.length !== 0">
+          Please fix these error(s):
+          <ul>
+            <li v-for="(error, index) in errors" :key="index">{{ error }}</li>
+          </ul>
+        </b-alert>
       </p>
       <slot></slot>
     </div>


### PR DESCRIPTION
The form errors were a bit hard to see for me, so I threw em in a `<b-alert>`

## Before
![screen shot 2018-10-19 at 4 45 59 pm](https://user-images.githubusercontent.com/2358694/47245383-a5943280-d3be-11e8-860d-529ebe5b57ea.png)


## After
![screen shot 2018-10-19 at 4 46 05 pm](https://user-images.githubusercontent.com/2358694/47245390-ab8a1380-d3be-11e8-8275-9f5fc71243e1.png)
