### PR TITLE
(Visibly) disable web3 login buttons if there's a web3 error

### DIFF
--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -25,20 +25,27 @@
             <IconBase iconName="microsoft" width="48" height="48" />
           </a>
           <b-link
-            :disabled="buttonDisabled"
             @click="loginWithMetaMask"
+            :disabled="web3LoginDisabled"
           >
             <IconBase iconName="metaMask" width="48" height="48" />
           </b-link>
           <b-link
-            :disabled="buttonDisabled"
             @click="loginWithCoinbase"
+            :disabled="web3LoginDisabled"
           >
             <IconBase iconName="coinbaseWallet" width="48" height="48" />
           </b-link>
         </div>
 
-        <p v-if="errorMessage">{{ errorMessage }}</p>
+        <b-alert
+          show
+          class="mt-5"
+          variant="danger"
+          v-if="errorMessage"
+        >
+          {{ errorMessage }}
+        </b-alert>
       </div>
       <div class="col-12 col-md-6 secondary">
         <div class="login-art"><img src="../assets/images/login-art.png" v-party-mode-activator /></div>
@@ -115,7 +122,7 @@ export default {
       }
     },
 
-    buttonDisabled() {
+    web3LoginDisabled() {
       switch (this.error) {
         case Web3Errors.Locked:
         case Web3Errors.WrongNetwork:
@@ -202,6 +209,9 @@ export default {
 
     &:first-child
       margin-left: 0
+
+    &.disabled
+      opacity: .5
 
   .logo
     max-width: 100px

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -111,17 +111,6 @@ export default {
       return 'Codex Viewer allows you to create, view, and transfer Codex Records'
     },
 
-    buttonMethod() {
-      switch (this.error) {
-        case Web3Errors.Unknown:
-        case Web3Errors.Missing:
-          return this.installWeb3
-
-        default:
-          return this.web3Login
-      }
-    },
-
     web3LoginDisabled() {
       switch (this.error) {
         case Web3Errors.Locked:


### PR DESCRIPTION
When the web3 buttons are disabled, they don't really _look_ disabled, so this PR just drops their opacity if they're disabled.

This PR also renames `buttonDisabled` to `web3LoginDisabled` since that's a little more accurate now that there are multiple buttons. It also removes the now-unused `buttonMethod` variable.

## Before
![screen shot 2018-10-23 at 4 42 25 pm](https://user-images.githubusercontent.com/2358694/47393054-13549d00-d6e4-11e8-8047-70e670e0d679.png)

## After
![screen shot 2018-10-23 at 4 42 09 pm](https://user-images.githubusercontent.com/2358694/47393063-18b1e780-d6e4-11e8-99d3-92e5644169b2.png)
