### PR TITLE
Add "transfer to unregistered emails" functionality

### DIFF
--- a/src/components/OAuth2AppTransferRecordForm.vue
+++ b/src/components/OAuth2AppTransferRecordForm.vue
@@ -19,7 +19,7 @@
       />
     </b-form-group>
     <b-form-group
-      label="Receiving Ethereum address"
+      label="Receiving Ethereum or Email Address"
       label-for="receivingAddress"
     >
       <b-form-input
@@ -27,7 +27,7 @@
         type="text"
         v-model="receivingAddress"
         required
-        placeholder="Enter the Ethereum address to send the record to"
+        placeholder="Enter the Ethereum or email address to send the record to"
       />
     </b-form-group>
     <b-button type="submit" variant="primary">Submit</b-button>
@@ -54,8 +54,11 @@ export default {
 
   methods: {
     onSubmit() {
+
+      const addressKey = this.receivingAddress.includes('@') ? 'email' : 'address'
+
       axios.put(`/v1/client/record/${this.recordId}/transfer/approve`, {
-        address: this.receivingAddress,
+        [addressKey]: this.receivingAddress,
       }, {
         headers: {
           Authorization: `Bearer ${this.accessToken}`,

--- a/src/components/modals/ApproveTransferModal.vue
+++ b/src/components/modals/ApproveTransferModal.vue
@@ -27,7 +27,7 @@
         After approving a transfer, the owner of the Ethereum address will have to accept the Record.
       </b-form-text>
     </b-form-group>
-    <!--
+
     <b-form-group
       label="Email address of the wallet owner (optional)"
       label-for="toEmailAddress" label-size="sm"
@@ -43,7 +43,7 @@
         we will send them an email once they've been approved to accept the Record.
       </b-form-text>
     </b-form-group>
-    -->
+
   </MetaMaskNotificationModal>
 </template>
 
@@ -91,11 +91,18 @@ export default {
     validate() {
       const errors = []
 
+      if (this.toEmailAddress) {
+        if (this.toEthAddress) {
+          errors.push('Specify Ethereum address OR email address, but not both')
+        }
+        return errors
+      }
+
       if (!this.toEthAddress) {
-        errors.push('Ethereum address is required')
+        errors.push('Ethereum address or email address is required')
       } else if (this.toEthAddress === this.user.address) {
         errors.push('You cannot transfer to yourself')
-      } else if (this.toEthAddress === this.codexRecord.approvedAddress) {
+      } else if (this.codexRecord.approvedAddress && this.toEthAddress === this.codexRecord.approvedAddress) {
         errors.push('This address has already been approved for transfer')
       } else if (!this.instance.utils.isAddress(this.toEthAddress)) {
         errors.push('Invalid Ethereum address')
@@ -106,7 +113,7 @@ export default {
 
     approveTransfer() {
       EventBus.$emit('events:record-click-transfer', this)
-      const input = [this.toEthAddress, this.codexRecord.tokenId]
+      const input = [this.toEmailAddress || this.toEthAddress, this.codexRecord.tokenId]
 
       // @NOTE: we don't .catch here so that the error bubbles up to MetaMaskNotificationModal
       return contractHelper('CodexRecord', 'approve', input, this.$store)

--- a/src/components/modals/ApproveTransferModal.vue
+++ b/src/components/modals/ApproveTransferModal.vue
@@ -10,7 +10,9 @@
     :requires-tokens="true"
     :validate="validate"
   >
+
     <b-form-group
+      v-if="showEthereumAddressField"
       label="Type or paste wallet address"
       label-for="toEthAddress"
       label-size="sm"
@@ -24,12 +26,14 @@
         spellcheck="false"
       />
       <b-form-text>
-        After approving a transfer, the owner of the Ethereum address will have to accept the Record.
+        After approving a transfer, the owner of the Ethereum address can accept
+        the Record.
       </b-form-text>
     </b-form-group>
 
     <b-form-group
-      label="Email address of the wallet owner (optional)"
+      v-else
+      label="Email address of the wallet owner"
       label-for="toEmailAddress" label-size="sm"
     >
       <b-form-input
@@ -39,10 +43,20 @@
         v-model="toEmailAddress"
       />
       <b-form-text>
-        If you know the email address of the person you are approving,
-        we will send them an email once they've been approved to accept the Record.
+        If you know the email address of the person you are approving, we will
+        send them an email once they've been approved to accept the Record.
       </b-form-text>
     </b-form-group>
+
+    <b-button
+      size="sm"
+      variant="link"
+      class="pl-0 pr-0"
+      v-if="user.type !== 'savvy'"
+      @click="toggleField()"
+    >
+      Transfer to an {{ showEthereumAddressField ? 'email' : 'Ethereum' }} address instead?
+    </b-button>
 
   </MetaMaskNotificationModal>
 </template>
@@ -69,6 +83,7 @@ export default {
     return {
       toEthAddress: null,
       toEmailAddress: null,
+      showEthereumAddressField: false,
     }
   },
 
@@ -77,7 +92,14 @@ export default {
     ...mapState('web3', ['instance']),
   },
 
+  mounted() {
+    if (this.user.type === 'savvy') {
+      this.showEthereumAddressField = true
+    }
+  },
+
   methods: {
+
     focusModal() {
       if (this.$refs.defaultModalFocus) {
         this.$refs.defaultModalFocus.focus()
@@ -88,24 +110,40 @@ export default {
       Object.assign(this.$data, this.$options.data.apply(this))
     },
 
+    toggleField() {
+
+      // savvy users aren't allowed to switch fields, since they can only
+      //  specify Ethereum addresses for approve()
+      if (this.user.type === 'savvy') {
+        this.showEthereumAddressField = true
+        return
+      }
+
+      this.toEthAddress = null
+      this.toEmailAddress = null
+      this.showEthereumAddressField = !this.showEthereumAddressField
+    },
+
     validate() {
       const errors = []
 
-      if (this.toEmailAddress) {
-        if (this.toEthAddress) {
-          errors.push('Specify Ethereum address OR email address, but not both')
+      if (this.showEthereumAddressField) {
+        if (!this.toEthAddress) {
+          errors.push('Ethereum address is required')
+        } else if (this.toEthAddress === this.user.address) {
+          errors.push('You cannot transfer to yourself')
+        } else if (this.toEthAddress === this.codexRecord.approvedAddress) {
+          errors.push('This address has already been approved for transfer')
+        } else if (!this.instance.utils.isAddress(this.toEthAddress)) {
+          errors.push('Invalid Ethereum address')
         }
         return errors
       }
 
-      if (!this.toEthAddress) {
-        errors.push('Ethereum address or email address is required')
-      } else if (this.toEthAddress === this.user.address) {
+      if (!this.toEmailAddress) {
+        errors.push('Email address is required')
+      } else if (this.toEmailAddress === this.user.email) {
         errors.push('You cannot transfer to yourself')
-      } else if (this.toEthAddress === this.codexRecord.approvedAddress) {
-        errors.push('This address has already been approved for transfer')
-      } else if (!this.instance.utils.isAddress(this.toEthAddress)) {
-        errors.push('Invalid Ethereum address')
       }
 
       return errors
@@ -113,7 +151,11 @@ export default {
 
     approveTransfer() {
       EventBus.$emit('events:record-click-transfer', this)
-      const input = [this.toEmailAddress || this.toEthAddress, this.codexRecord.tokenId]
+
+      const input = [
+        this.showEthereumAddressField ? this.toEthAddress : this.toEmailAddress,
+        this.codexRecord.tokenId,
+      ]
 
       // @NOTE: we don't .catch here so that the error bubbles up to MetaMaskNotificationModal
       return contractHelper('CodexRecord', 'approve', input, this.$store)

--- a/src/components/modals/ApproveTransferModal.vue
+++ b/src/components/modals/ApproveTransferModal.vue
@@ -102,7 +102,7 @@ export default {
         errors.push('Ethereum address or email address is required')
       } else if (this.toEthAddress === this.user.address) {
         errors.push('You cannot transfer to yourself')
-      } else if (this.codexRecord.approvedAddress && this.toEthAddress === this.codexRecord.approvedAddress) {
+      } else if (this.toEthAddress === this.codexRecord.approvedAddress) {
         errors.push('This address has already been approved for transfer')
       } else if (!this.instance.utils.isAddress(this.toEthAddress)) {
         errors.push('Invalid Ethereum address')

--- a/src/components/modals/PrivacySettingsModal.vue
+++ b/src/components/modals/PrivacySettingsModal.vue
@@ -167,6 +167,9 @@ export default {
     updateRecord(event) {
       event.preventDefault()
 
+      // @TODO: figure out how to allow users to specify email addresses as well
+      //  as ethereum addresses for the whitelist addresses
+
       // if they typed in an address but didn't click "add", add it for them
       if (this.newWhitelistedAddress !== null) {
         this.addWhitelistedAddress()

--- a/src/util/api/pendingUser.js
+++ b/src/util/api/pendingUser.js
@@ -1,0 +1,12 @@
+import callApi from './callApi'
+
+export default {
+  getStats: (pendingUserCode) => {
+    const requestOptions = {
+      method: 'get',
+      url: `/pending-users/${pendingUserCode}/stats`,
+    }
+
+    return callApi(requestOptions)
+  },
+}

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -23,10 +23,7 @@
           associated with the email <strong>{{ pendingUserStats.email }}</strong> to
           claim them!
 
-          <!--
-            @TODO: add a "claim with a different email?" link here when that
-            flow is implemented
-          -->
+          <!-- add a "claim with a different email" link here if/when that flow is implemented -->
         </b-alert>
 
         <p class="mt-5 mb-3">

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -10,6 +10,25 @@
 
         <h1>{{ title }}</h1>
         <div class="lead">{{ description }}</div>
+
+        <b-alert
+          show
+          class="mt-5"
+          variant="secondary"
+          v-if="pendingUserStats && pendingUserStats.email"
+        >
+          You have {{ pendingUserStats.numApproved }}
+          Codex {{ pendingUserStats.numApproved === 1 ? 'Record' : 'Records' }}
+          waiting to be claimed. Log in with an Identity Provider below
+          associated with the email <strong>{{ pendingUserStats.email }}</strong> to
+          claim them!
+
+          <!--
+            @TODO: add a "claim with a different email?" link here when that
+            flow is implemented
+          -->
+        </b-alert>
+
         <p class="mt-5 mb-3">
           <b>Sign in below to get started</b>
         </p>
@@ -52,6 +71,7 @@ import { mapState } from 'vuex'
 
 import User from '../util/api/user'
 import config from '../util/config'
+import PendingUser from '../util/api/pendingUser'
 import { Web3Errors, Networks } from '../util/constants/web3'
 
 import IconBase from '../components/icons/IconBase'
@@ -76,6 +96,20 @@ export default {
       // Facebook and Microsoft support HTTPS for redirect_uri so we disable these in ropsten
       disableFacebook: config.expectedNetworkName === 'ropsten',
       disableMicrosoft: config.expectedNetworkName === 'ropsten',
+
+      pendingUserStats: null,
+    }
+  },
+
+  created() {
+    // remove pendingUserCode from the query params if specified
+    if (this.$route.query.pendingUserCode) {
+      const oAuth2LoginQueryString = `?pendingUserCode=${this.$route.query.pendingUserCode}`
+      this.googleLoginUrl += oAuth2LoginQueryString
+      this.facebookLoginUrl += oAuth2LoginQueryString
+      this.microsoftLoginUrl += oAuth2LoginQueryString
+      this.getPendingUserStats(this.$route.query.pendingUserCode)
+      this.$router.replace({ name: this.$route.name })
     }
   },
 
@@ -204,6 +238,16 @@ export default {
             }
           })
       })
+    },
+    getPendingUserStats(pendingUserCode) {
+      PendingUser.getStats(pendingUserCode)
+        .then((pendingUserStats) => {
+          this.pendingUserStats = pendingUserStats
+        })
+        .catch((error) => {
+          // @TODO: should anything else happen here?
+          logger(error)
+        })
     },
   },
 }

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -64,6 +64,7 @@
 
 <script>
 import is from 'is_js'
+import debug from 'debug'
 import { mapState } from 'vuex'
 
 import User from '../util/api/user'
@@ -72,6 +73,8 @@ import PendingUser from '../util/api/pendingUser'
 import { Web3Errors, Networks } from '../util/constants/web3'
 
 import IconBase from '../components/icons/IconBase'
+
+const logger = debug('app:component:login-view')
 
 export default {
   name: 'LoginView',
@@ -242,7 +245,8 @@ export default {
           this.pendingUserStats = pendingUserStats
         })
         .catch((error) => {
-          // @TODO: should anything else happen here?
+          // do nothing, since this likely means the pending user code was
+          //  invalid
           logger(error)
         })
     },


### PR DESCRIPTION
This PR adds a `pendingUserCode` query parameter to the login page to support the new "transfer to unregistered emails" flow.

Also included are some minor frontend change that allow emails to be specified in place of an Ethereum address. @johnhforrest You'll probably wanna give these two files a look over and add any changes you were thinking of:

```
OAuth2AppTransferRecordForm.vue
ApproveTransferModal.vue
```

**IMPORTANT NOTE THAT I JUST THOUGHT OF**: we need to hide the email section in `ApproveTransferModal.vue` for non-simple users since savvy users shouldn't be able to send an email string in place of an address. That'll also probably affect the form validation too.

[See the corresponding back-end PR here.](https://github.com/codex-protocol/private-service.codex-registry-api/pull/25)