### PR TITLE
Fixes bad login redirect logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -131,16 +131,10 @@ export default {
         //  In fact, I think we need to do this separately because we leverage this information for provenance (un-auth flow)
         .then(this.$store.dispatch('oauth2/FETCH_CLIENTS'))
         .then(() => {
-          // Once we've authenticated the user, take them to the collection page
-          if (this.$route.name === 'collection') {
-            this.$store.commit('auth/SET_IS_LOADED', {
-              isLoaded: true,
-            })
-          } else {
-            this.$router.replace({
-              name: this.$route.meta.ifAuthenticatedRedirectTo || 'collection',
-            })
+          if (this.$route.meta.ifAuthenticatedRedirectTo) {
+            this.$router.replace({ name: this.$route.meta.ifAuthenticatedRedirectTo })
           }
+          this.$store.commit('auth/SET_IS_LOADED', { isLoaded: true })
         })
         .catch((error) => {
           if (this.user) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -133,8 +133,9 @@ export default {
         .then(() => {
           if (this.$route.meta.ifAuthenticatedRedirectTo) {
             this.$router.replace({ name: this.$route.meta.ifAuthenticatedRedirectTo })
+          } else {
+            this.$store.commit('auth/SET_IS_LOADED', { isLoaded: true })
           }
-          this.$store.commit('auth/SET_IS_LOADED', { isLoaded: true })
         })
         .catch((error) => {
           if (this.user) {

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -197,9 +197,10 @@ export default {
             return this.$store.dispatch('oauth2/FETCH_CLIENTS')
           })
           .then(() => {
-            this.$router.replace({
-              name: this.$route.meta.ifAuthenticatedRedirectTo || 'collection',
-            })
+            if (this.$route.meta.ifAuthenticatedRedirectTo) {
+              this.$router.replace({ name: this.$route.meta.ifAuthenticatedRedirectTo })
+            }
+            this.$store.commit('auth/SET_IS_LOADED', { isLoaded: true })
           })
       })
     },

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -199,8 +199,9 @@ export default {
           .then(() => {
             if (this.$route.meta.ifAuthenticatedRedirectTo) {
               this.$router.replace({ name: this.$route.meta.ifAuthenticatedRedirectTo })
+            } else {
+              this.$store.commit('auth/SET_IS_LOADED', { isLoaded: true })
             }
-            this.$store.commit('auth/SET_IS_LOADED', { isLoaded: true })
           })
       })
     },


### PR DESCRIPTION
Currently if you try to initially load any route other than `collection` as an authenticated user, the authentication logic will always kick you to your collection page. This has the effect of always sending users to their collection page when they refresh on a record detail page, or on their transfers page, etc.

This PR will redirect the user to the route name defined in the route's `ifAuthenticatedRedirectTo` property, or perform no redirect at all if that field is empty.