### PR TITLE
Handle Empty Galleries

### DIFF
--- a/src/views/GalleryListView.vue
+++ b/src/views/GalleryListView.vue
@@ -7,7 +7,7 @@
         <div v-if="galleries.length">
           <b-card-group deck>
             <GalleryListItem
-              v-if="gallery.codexRecords"
+              v-if="gallery.codexRecords && gallery.codexRecords.length !== 0"
               v-for="gallery in galleries"
               :gallery="gallery"
               :key="gallery.id"

--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -98,10 +98,14 @@ export default {
     getGallery() {
       Gallery.getGallery(this.galleryShareCode)
         .then((gallery) => {
+          if (!gallery.codexRecords || gallery.codexRecords.length === 0) {
+            throw new Error(`${gallery.name} has no Codex Records to show.`)
+          }
           this.gallery = gallery
         })
         .catch((error) => {
           EventBus.$emit('toast:error', `Could not get gallery: ${error.message}`)
+          this.$router.replace({ name: 'galleries' })
         })
     },
   },


### PR DESCRIPTION
This PR hides galleries that have no records from the list view and redirects back to list view if an empty gallery page is loaded.