### PR TITLE
Moves query string handling into vuex

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -130,7 +130,7 @@ export default {
 
   computed: {
     ...mapGetters('auth', ['isAuthenticated']),
-    ...mapState('app', ['isLoaded', 'isRefreshing']),
+    ...mapState('app', ['isLoaded']),
     ...mapState('auth', ['user', 'authToken']),
 
     hideSideBar() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,22 +102,27 @@ export default {
       this.$store.commit('app/SET_IS_LOADED', { isLoaded: true })
     }
 
-    const { query } = this.$route
-    const authToken = query.authToken || this.authToken
-
-    if (authToken) {
-      this.$store.dispatch('auth/LOGIN_FROM_CACHED_TOKEN', authToken)
-        .then(() => {
-          if (this.$route.meta.ifAuthenticatedRedirectTo) {
-            this.$router.replace({ name: this.$route.meta.ifAuthenticatedRedirectTo })
+    this.$store.dispatch('app/HANDLE_QUERY_PARAMS')
+      .then(() => {
+        return new Promise((resolve) => {
+          if (this.authToken) {
+            this.$store.dispatch('auth/LOGIN_FROM_CACHED_TOKEN')
+              .then(() => {
+                if (this.$route.meta.ifAuthenticatedRedirectTo) {
+                  this.$router.replace({
+                    name: this.$route.meta.ifAuthenticatedRedirectTo,
+                  }, resolve)
+                } else {
+                  resolve()
+                }
+              })
           } else {
-            setIsLoaded()
+            resolve()
           }
         })
-        .catch(setIsLoaded)
-    } else {
-      setIsLoaded()
-    }
+      })
+      .then(setIsLoaded)
+      .catch(setIsLoaded)
   },
 
   beforeDestroy() {
@@ -127,7 +132,7 @@ export default {
 
   computed: {
     ...mapGetters('auth', ['isAuthenticated']),
-    ...mapState('app', ['isLoaded']),
+    ...mapState('app', ['isLoaded', 'isRefreshing']),
     ...mapState('auth', ['user', 'authToken']),
 
     hideSideBar() {
@@ -136,18 +141,6 @@ export default {
 
     recordId() {
       return this.$route.params.recordId
-    },
-  },
-
-  watch: {
-    $route(newRoute, oldRoute) {
-      if (!this.isLoaded) {
-        // If the route changes as a result of authentication (e.g., /login to /collection)
-        //  then we only mark loading complete after the new route has been loaded
-        this.$store.commit('app/SET_IS_LOADED', {
-          isLoaded: true,
-        })
-      }
     },
   },
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -133,7 +133,6 @@ if (config.showManageTokensPage) {
 router.beforeEach((to, from, next) => {
 
   if (to.meta.ifAuthenticatedRedirectTo && store.getters['auth/isAuthenticated']) {
-    // debugger // eslint-disable-line
     return next({ name: to.meta.ifAuthenticatedRedirectTo })
   }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -133,6 +133,7 @@ if (config.showManageTokensPage) {
 router.beforeEach((to, from, next) => {
 
   if (to.meta.ifAuthenticatedRedirectTo && store.getters['auth/isAuthenticated']) {
+    // debugger // eslint-disable-line
     return next({ name: to.meta.ifAuthenticatedRedirectTo })
   }
 

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -5,27 +5,46 @@ import router from '../../../router'
 
 const logger = debug('app:store:app:actions')
 
+const queryParamsToHandle = {
+  email: {
+    mutationName: 'SET_EMAIL_ADDRESS_TO_CONFIRM',
+  },
+  pendingUserCode: {
+    mutationName: 'SET_PENDING_USER_CODE',
+  },
+
+  // If there's a cached authToken in localstorage this will replace it with
+  //  the one from the query string
+  authToken: {
+    mutationName: 'auth/SET_AUTH_STATE',
+    mutationConfiguration: { root: true },
+  },
+
+  // API error handling
+  errorCode: {
+    mutationName: 'SET_API_ERROR_CODE',
+  },
+  error: {
+    mutationName: 'SET_API_ERROR_MESSAGE',
+  },
+}
+
 export default {
   HANDLE_QUERY_PARAMS({ commit, rootState }) {
     logger('HANDLE_QUERY_PARAMS action being executed')
 
+    let paramRemoved = false
     const { query } = rootState.route
 
-    // @TODO: Strip errors from here too
-    const {
-      email,
-      authToken,
-      pendingUserCode,
-    } = query
+    Object.keys(queryParamsToHandle).forEach((key) => {
+      if (query[key]) {
+        const param = queryParamsToHandle[key]
 
-    if (email) commit('SET_EMAIL_ADDRESS_TO_CONFIRM', email)
-    if (pendingUserCode) commit('SET_PENDING_USER_CODE', pendingUserCode)
+        commit(param.mutationName, query[key], param.mutationConfiguration)
+        paramRemoved = true
+      }
+    })
 
-    // If there's a cached authToken in localstorage this will replace it with
-    //  the one from the query string
-    if (authToken) commit('auth/SET_AUTH_STATE', { authToken }, { root: true })
-
-    const paramRemoved = !!(email || authToken || pendingUserCode)
     if (paramRemoved) {
       router.replace(rootState.route.name)
     }

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -1,9 +1,36 @@
 import axios from 'axios'
 import debug from 'debug'
 
+import router from '../../../router'
+
 const logger = debug('app:store:app:actions')
 
 export default {
+  HANDLE_QUERY_PARAMS({ commit, rootState }) {
+    logger('HANDLE_QUERY_PARAMS action being executed')
+
+    const { query } = rootState.route
+
+    // @TODO: Strip errors from here too
+    const {
+      email,
+      authToken,
+      pendingUserCode,
+    } = query
+
+    if (email) commit('SET_EMAIL_ADDRESS_TO_CONFIRM', email)
+    if (pendingUserCode) commit('SET_PENDING_USER_CODE', pendingUserCode)
+
+    // If there's a cached authToken in localstorage this will replace it with
+    //  the one from the query string
+    if (authToken) commit('auth/SET_AUTH_STATE', { authToken }, { root: true })
+
+    const paramRemoved = !!(email || authToken || pendingUserCode)
+    if (paramRemoved) {
+      router.replace(rootState.route.name)
+    }
+  },
+
   FETCH_VERIFIED_USERS({ commit }) {
     logger('FETCH_VERIFIED_USERS action being executed')
 

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -33,7 +33,6 @@ export default {
   HANDLE_QUERY_PARAMS({ commit, rootState }) {
     logger('HANDLE_QUERY_PARAMS action being executed')
 
-    let paramRemoved = false
     const { query } = rootState.route
 
     Object.keys(queryParamsToHandle).forEach((key) => {
@@ -41,13 +40,10 @@ export default {
         const param = queryParamsToHandle[key]
 
         commit(param.mutationName, query[key], param.mutationConfiguration)
-        paramRemoved = true
       }
     })
 
-    if (paramRemoved) {
-      router.replace(rootState.route.name)
-    }
+    router.replace(rootState.route.name)
   },
 
   FETCH_VERIFIED_USERS({ commit }) {

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -32,13 +32,16 @@ export default {
     currentState.emailAddressToConfirm = emailAddress
   },
 
-  SET_API_ERROR(currentState, { code, message }) {
-    logMutation('SET_API_ERROR', message)
+  SET_API_ERROR_CODE(currentState, code) {
+    logMutation('SET_API_ERROR_CODE', code)
 
-    currentState.apiError = {
-      code,
-      message,
-    }
+    currentState.apiErrorCode = code
+  },
+
+  SET_API_ERROR_MESSAGE(currentState, message) {
+    logMutation('SET_API_ERROR_MESSAGE', message)
+
+    currentState.apiErrorMessage = message
   },
 
   SET_IS_LOADED(currentState, { isLoaded }) {

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -3,7 +3,8 @@ export default () => {
     emailAddressToConfirm: null,
     pendingUserCode: null,
     verifiedUsers: null,
-    apiError: null,
+    apiErrorCode: null,
+    apiErrorMessage: null,
     isLoaded: false,
   }
 }

--- a/src/store/modules/auth/actions.js
+++ b/src/store/modules/auth/actions.js
@@ -11,12 +11,8 @@ export default {
   //  from the API. If it's a simple user, we register Web3 using Infura. If it's a savvy user
   //  we attempt to register Web3 using their wallet provider. If there is no wallet provider,
   //  we kick them back to the login page with an error.
-  LOGIN_FROM_CACHED_TOKEN({ commit, dispatch, state }, authToken) {
+  LOGIN_FROM_CACHED_TOKEN({ commit, dispatch }) {
     logger('LOGIN_FROM_CACHED_TOKEN action being executed')
-
-    commit('SET_AUTH_STATE', {
-      authToken,
-    })
 
     return User.getUser()
       .then((user) => {

--- a/src/store/modules/auth/actions.js
+++ b/src/store/modules/auth/actions.js
@@ -63,9 +63,7 @@ export default {
           signedData,
         })
           .then((response) => {
-            commit('SET_AUTH_STATE', {
-              authToken: response.token,
-            })
+            commit('SET_AUTH_STATE', response.token)
 
             commit('SET_USER', {
               user: response.user,
@@ -93,7 +91,8 @@ export default {
     logger('HANDLE_LOGIN_ERROR action being executed')
 
     if (state.user && state.user.type === 'simple') {
-      commit('app/SET_API_ERROR', error, { root: true })
+      // @TODO: Fix
+      // commit('app/SET_API_ERROR', error, { root: true })
     } else {
       commit('web3/SET_REGISTRATION_ERROR', {
         message: 'Error while registering Web3',

--- a/src/store/modules/auth/actions.js
+++ b/src/store/modules/auth/actions.js
@@ -88,11 +88,12 @@ export default {
   },
 
   HANDLE_LOGIN_ERROR({ commit, dispatch, state }, error) {
-    logger('HANDLE_LOGIN_ERROR action being executed')
+    logger('HANDLE_LOGIN_ERROR action being executed', error)
 
     if (state.user && state.user.type === 'simple') {
-      // @TODO: Fix
-      // commit('app/SET_API_ERROR', error, { root: true })
+      // @TODO: Right now we're just sending the entire error object
+      //  Once the API has been updated to return specific error codes we can pass that along instead
+      commit('app/SET_API_ERROR_CODE', error, { root: true })
     } else {
       commit('web3/SET_REGISTRATION_ERROR', {
         message: 'Error while registering Web3',

--- a/src/store/modules/auth/getters.js
+++ b/src/store/modules/auth/getters.js
@@ -1,6 +1,6 @@
 export default {
   isAuthenticated: (state) => {
-    return !!state.authToken
+    return !!state.user
   },
 
   isAdmin: (state) => {

--- a/src/store/modules/auth/mutations.js
+++ b/src/store/modules/auth/mutations.js
@@ -12,7 +12,7 @@ const logMutation = (mutationName, payload) => {
 }
 
 export default {
-  SET_AUTH_STATE(currentState, { authToken }) {
+  SET_AUTH_STATE(currentState, authToken) {
     logMutation('SET_AUTH_STATE', authToken)
 
     axios.defaults.headers.common.Authorization = authToken

--- a/src/store/modules/web3/actions.js
+++ b/src/store/modules/web3/actions.js
@@ -9,7 +9,6 @@ const logger = debug('app:store:web3:actions')
 
 const registerWalletProvider = () => {
   return new Promise((resolve, reject) => {
-    // @TODO: Test this when the new custom build becomes stable
     if (window.ethereum) {
       window.ethereum.enable()
         .then(() => {

--- a/src/views/ConfirmEmailView.vue
+++ b/src/views/ConfirmEmailView.vue
@@ -66,11 +66,11 @@ export default {
   },
 
   computed: {
-    ...mapState('app', ['apiError', 'emailAddressToConfirm']),
+    ...mapState('app', ['apiErrorCode', 'emailAddressToConfirm']),
   },
 
   mounted() {
-    if (this.apiError) {
+    if (this.apiErrorCode) {
       this.buttonText = 'Resend Confirmation Email?'
       this.headerText = 'Could Not Confirm Your Email Address'
       this.bodyText = 'There was an error while confirming your email address.'

--- a/src/views/ConfirmEmailView.vue
+++ b/src/views/ConfirmEmailView.vue
@@ -69,14 +69,6 @@ export default {
     ...mapState('app', ['apiError', 'emailAddressToConfirm']),
   },
 
-  created() {
-    // remove email from the query params if specified
-    if (this.$route.query.email) {
-      this.$store.commit('app/SET_EMAIL_ADDRESS_TO_CONFIRM', this.$route.query.email)
-      this.$router.replace({ name: this.$route.name })
-    }
-  },
-
   mounted() {
     if (this.apiError) {
       this.buttonText = 'Resend Confirmation Email?'

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -101,11 +101,7 @@ export default {
   },
 
   created() {
-    // remove pendingUserCode from the query params if specified
-    if (this.$route.query.pendingUserCode) {
-      this.$store.commit('app/SET_PENDING_USER_CODE', this.$route.query.pendingUserCode)
-      this.$router.replace({ name: this.$route.name })
-    } else if (this.pendingUserCode) {
+    if (this.pendingUserCode) {
       const oAuth2LoginQueryString = `?pendingUserCode=${this.pendingUserCode}`
       this.googleLoginUrl += oAuth2LoginQueryString
       this.facebookLoginUrl += oAuth2LoginQueryString


### PR DESCRIPTION
- Creates a generic way to parse query string params and putting that state into vuex
- Fixes the priority of authTokens if multiple are present. Will always prefer QS over localstorage.
- Fixes error handling for if an error is returned when doing OAuth2 login (looks like I broke the error handling at some point). Right now we use a generic error message. Later, I would like to have the API pass an error code as opposed to a message that the UI knows how to map to the appropriate string.

Haven't done the login route redirect changes yet, I will have to punt those for now.