### PR TITLE
Adds ability to whitelist email addresses (even unregistered emails)

### DIFF
--- a/src/components/modals/PrivacySettingsModal.vue
+++ b/src/components/modals/PrivacySettingsModal.vue
@@ -105,7 +105,7 @@
         <div v-if="whitelistedEmails.length > 0">
           <div v-for="email in whitelistedEmails" :key="email">
             <DisplayName :name="email" />
-            <span class="close" v-on:click="removeWhitelistedEmail(email)">×</span>
+            <span class="close" @click="removeWhitelistedEmail(email)">×</span>
           </div>
         </div>
         <div v-if="whitelistedAddresses.length === 0 && whitelistedEmails.length === 0">

--- a/src/components/modals/PrivacySettingsModal.vue
+++ b/src/components/modals/PrivacySettingsModal.vue
@@ -49,21 +49,51 @@
       label-for="address"
       label-size="sm"
     >
-      <b-form-text>
-        Wallet Address
-      </b-form-text>
-      <b-input-group class="grant-access">
-        <b-form-input
-          id="address"
-          type="text"
-          placeholder="e.g. 0x627306090aba..."
-          v-model="newWhitelistedAddress"
-          spellcheck="false"
-        />
-        <b-input-group-append>
-          <b-button variant="primary" @click="addWhitelistedAddress()">Add</b-button>
-        </b-input-group-append>
-      </b-input-group>
+      <div v-if="showEthereumAddressField">
+        <b-form-text>
+          Wallet Address
+        </b-form-text>
+        <b-input-group class="grant-access">
+          <b-form-input
+            id="address"
+            type="text"
+            spellcheck="false"
+            v-model="newWhitelistedAddress"
+            placeholder="e.g. 0x627306090aba..."
+          />
+          <b-input-group-append>
+            <b-button variant="primary" @click="addWhitelistedAddress()">Add</b-button>
+          </b-input-group-append>
+        </b-input-group>
+      </div>
+
+      <div v-else>
+        <b-form-text>
+          Email Address
+        </b-form-text>
+        <b-input-group class="grant-access">
+          <b-form-input
+            id="email"
+            type="email"
+            spellcheck="false"
+            v-model="newWhitelistedEmail"
+            placeholder="e.g., user@example.com"
+          />
+          <b-input-group-append>
+            <b-button variant="primary" @click="addWhitelistedEmail()">Add</b-button>
+          </b-input-group-append>
+        </b-input-group>
+      </div>
+
+      <b-button
+        size="sm"
+        variant="link"
+        class="pl-0 pr-0"
+        v-if="supportEmailAccounts"
+        @click="toggleWhitelistField()"
+      >
+        Share with an {{ showEthereumAddressField ? 'email' : 'Ethereum' }} address instead?
+      </b-button>
 
       <div class="mt-4">
         <div v-if="whitelistedAddresses.length > 0">
@@ -72,7 +102,13 @@
             <span class="close" v-on:click="removeWhitelistedAddress(address)">×</span>
           </div>
         </div>
-        <div v-else>
+        <div v-if="whitelistedEmails.length > 0">
+          <div v-for="email in whitelistedEmails" :key="email">
+            <DisplayName :name="email" />
+            <span class="close" v-on:click="removeWhitelistedEmail(email)">×</span>
+          </div>
+        </div>
+        <div v-if="whitelistedAddresses.length === 0 && whitelistedEmails.length === 0">
           <small class="text-muted">
             You have not shared this record with any other addresses. Add one above to allow read-only access for that address.
           </small>
@@ -87,9 +123,10 @@
 import { mapState } from 'vuex'
 import debug from 'debug'
 
-import DisplayName from '../util/DisplayName'
+import config from '../../util/config'
 import Record from '../../util/api/record'
 import EventBus from '../../util/eventBus'
+import DisplayName from '../util/DisplayName'
 
 const logger = debug('app:component:privacy-settings-modal')
 
@@ -105,15 +142,20 @@ export default {
   data() {
     return {
       modalVisible: false,
+      newWhitelistedEmail: null,
       newWhitelistedAddress: null,
+      showEthereumAddressField: true,
       isPrivate: this.codexRecord.isPrivate,
       isInGallery: this.codexRecord.isInGallery,
+      supportEmailAccounts: config.supportEmailAccounts,
+      whitelistedEmails: Array.from(this.codexRecord.whitelistedEmails) || [],
       whitelistedAddresses: Array.from(this.codexRecord.whitelistedAddresses) || [],
     }
   },
 
   computed: {
     ...mapState('auth', ['user']),
+    ...mapState('web3', ['instance']),
 
     isPublic: {
       get: function getIsPublic() {
@@ -123,6 +165,14 @@ export default {
         this.isPrivate = !newValue
       },
     },
+  },
+
+  mounted() {
+    // by default, show the ethereum address field to savvy users and the email
+    //  field to simple users
+    if (this.user.type !== 'savvy' && config.supportEmailAccounts) {
+      this.showEthereumAddressField = false
+    }
   },
 
   methods: {
@@ -142,12 +192,23 @@ export default {
       }
     },
 
-    addWhitelistedAddress() {
+    toggleWhitelistField() {
 
-      const addressToAdd = this.newWhitelistedAddress
+      if (!config.supportEmailAccounts) {
+        this.showEthereumAddressField = true
+        return
+      }
+
+      this.toEthAddress = null
+      this.toEmailAddress = null
+      this.showEthereumAddressField = !this.showEthereumAddressField
+    },
+
+    addWhitelistedAddress(addressToAdd = this.newWhitelistedAddress) {
 
       if (
         addressToAdd !== null &&
+        this.instance.utils.isAddress(addressToAdd) &&
         !this.whitelistedAddresses.includes(addressToAdd) &&
         addressToAdd.toLowerCase() !== this.user.address.toLowerCase()
       ) {
@@ -164,11 +225,33 @@ export default {
       })
     },
 
+    addWhitelistedEmail(emailToAdd = this.newWhitelistedEmail) {
+
+      if (
+        emailToAdd !== null &&
+        !this.whitelistedEmails.includes(emailToAdd) &&
+        (!this.user.email || emailToAdd.toLowerCase() !== this.user.email.toLowerCase())
+      ) {
+        this.whitelistedEmails.push(emailToAdd)
+      }
+
+      this.newWhitelistedEmail = null
+
+    },
+
+    removeWhitelistedEmail(emailToRemove) {
+      this.whitelistedEmails = this.whitelistedEmails.filter((whitelistedEmail) => {
+        return whitelistedEmail !== emailToRemove
+      })
+    },
+
     updateRecord(event) {
       event.preventDefault()
 
-      // @TODO: figure out how to allow users to specify email addresses as well
-      //  as ethereum addresses for the whitelist addresses
+      // if they typed in an email but didn't click "add", add it for them
+      if (this.newWhitelistedEmail !== null) {
+        this.addWhitelistedEmail()
+      }
 
       // if they typed in an address but didn't click "add", add it for them
       if (this.newWhitelistedAddress !== null) {
@@ -178,6 +261,7 @@ export default {
       const dataToUpdate = {
         isPrivate: this.isPrivate,
         isInGallery: this.isInGallery,
+        whitelistedEmails: this.whitelistedEmails,
         whitelistedAddresses: this.whitelistedAddresses,
       }
 

--- a/src/components/modals/PrivacySettingsModal.vue
+++ b/src/components/modals/PrivacySettingsModal.vue
@@ -207,8 +207,7 @@ export default {
     addWhitelistedAddress(addressToAdd = this.newWhitelistedAddress) {
 
       if (
-        addressToAdd !== null &&
-        this.instance.utils.isAddress(addressToAdd) &&
+        this.instance.utils.isAddress(addressToAdd) && // this also handles null values
         !this.whitelistedAddresses.includes(addressToAdd) &&
         addressToAdd.toLowerCase() !== this.user.address.toLowerCase()
       ) {

--- a/src/components/modals/PrivacySettingsModal.vue
+++ b/src/components/modals/PrivacySettingsModal.vue
@@ -193,12 +193,6 @@ export default {
     },
 
     toggleWhitelistField() {
-
-      if (!config.supportEmailAccounts) {
-        this.showEthereumAddressField = true
-        return
-      }
-
       this.toEthAddress = null
       this.toEmailAddress = null
       this.showEthereumAddressField = !this.showEthereumAddressField

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -17,11 +17,42 @@
           variant="secondary"
           v-if="pendingUserStats && pendingUserStats.email"
         >
-          You have {{ pendingUserStats.numApproved > 0 ? pendingUserStats.numApproved : '' }}
-          Codex {{ pendingUserStats.numApproved === 1 ? 'Record' : 'Records' }}
-          waiting to be claimed. Log in with an Identity Provider below
-          associated with the email <strong>{{ pendingUserStats.email }}</strong> to
-          claim {{ pendingUserStats.numApproved === 1 ? 'it' : 'them' }}!
+
+          <!--
+            only show the "you have X records shared with you" message if
+            they don't have any records waiting to be claimed (which is a "more
+            important" message to show), since combining the two is kind of
+            complicated
+          -->
+          <span v-if="!pendingUserStats.numApproved && pendingUserStats.numWhitelisted">
+            {{ pendingUserStats.numWhitelisted }}
+            Codex {{ pendingUserStats.numWhitelisted === 1 ? 'Record' : 'Records' }}
+            {{ pendingUserStats.numWhitelisted === 1 ? 'has' : 'have' }} been
+            shared with you. Log in with an Identity Provider below associated
+            with the email <strong>{{ pendingUserStats.email }}</strong> to view
+            {{ pendingUserStats.numWhitelisted === 1 ? 'it' : 'them' }}!
+          </span>
+
+          <span v-if="pendingUserStats.numWhitelisted">
+            You have {{ pendingUserStats.numApproved }}
+            Codex {{ pendingUserStats.numApproved === 1 ? 'Record' : 'Records' }}
+            waiting to be claimed. Log in with an Identity Provider below
+            associated with the email <strong>{{ pendingUserStats.email }}</strong>
+            to claim {{ pendingUserStats.numApproved === 1 ? 'it' : 'them' }}!
+          </span>
+
+          <!--
+            this is a generic message that will show if this pending user has
+            nothing available... this can only really happen if someone approves
+            an email address, then they approve someone else before the user can
+            click their email - maybe this shouldn't even be shown since it's a
+            little missleading?
+          -->
+          <span v-else>
+            Log in with an Identity Provider below associated with the email
+            <strong>{{ pendingUserStats.email }}</strong> to see what's waiting
+            for you!
+          </span>
 
           <!-- add a "claim with a different email" link here if/when that flow is implemented -->
         </b-alert>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -15,45 +15,18 @@
           show
           class="mt-5"
           variant="secondary"
-          v-if="pendingUserStats && pendingUserStats.email"
+          v-if="pendingUserMessage"
         >
-
           <!--
-            only show the "you have X records shared with you" message if
-            they don't have any records waiting to be claimed (which is a "more
-            important" message to show), since combining the two is kind of
-            complicated
+            @NOTE: using v-html here should be fine, since the only user-defined
+            data is the email address... and the database verifies all email
+            addresses when creating users
+
+            even if someone could put some malicious text into an invited user's
+            email field, nobody would ever actually recieve an email with a link
+            that would generate this page since the email would be invalid...
           -->
-          <span v-if="!pendingUserStats.numApproved && pendingUserStats.numWhitelisted">
-            {{ pendingUserStats.numWhitelisted }}
-            Codex {{ pendingUserStats.numWhitelisted === 1 ? 'Record' : 'Records' }}
-            {{ pendingUserStats.numWhitelisted === 1 ? 'has' : 'have' }} been
-            shared with you. Log in with an Identity Provider below associated
-            with the email <strong>{{ pendingUserStats.email }}</strong> to view
-            {{ pendingUserStats.numWhitelisted === 1 ? 'it' : 'them' }}!
-          </span>
-
-          <span v-if="pendingUserStats.numWhitelisted">
-            You have {{ pendingUserStats.numApproved }}
-            Codex {{ pendingUserStats.numApproved === 1 ? 'Record' : 'Records' }}
-            waiting to be claimed. Log in with an Identity Provider below
-            associated with the email <strong>{{ pendingUserStats.email }}</strong>
-            to claim {{ pendingUserStats.numApproved === 1 ? 'it' : 'them' }}!
-          </span>
-
-          <!--
-            this is a generic message that will show if this pending user has
-            nothing available... this can only really happen if someone approves
-            an email address, then they approve someone else before the user can
-            click their email - maybe this shouldn't even be shown since it's a
-            little missleading?
-          -->
-          <span v-else>
-            Log in with an Identity Provider below associated with the email
-            <strong>{{ pendingUserStats.email }}</strong> to see what's waiting
-            for you!
-          </span>
-
+          <span v-html="pendingUserMessage"></span>
           <!-- add a "claim with a different email" link here if/when that flow is implemented -->
         </b-alert>
 
@@ -194,6 +167,57 @@ export default {
         case 'metaMask':
           return 'https://www.metamask.io'
       }
+    },
+
+    pendingUserMessage() {
+
+      const { numApproved, numWhitelisted, email } = this.pendingUserStats || {}
+
+      if (!email) {
+        return null
+      }
+
+      // always show the "you have X records waiting to be claimed" message,
+      //  even if they also have some whitelisted records, since this is the
+      //  "most important" message to show and combining the two is kind of
+      //  complicated
+      if (numApproved > 0) {
+
+        const [recordOrRecords, itOrThem] = numApproved > 1
+          ? ['Records', 'them']
+          : ['Record', 'it']
+
+        return `
+          You have ${numApproved} Codex ${recordOrRecords} waiting to be
+          claimed. Log in with an Identity Provider associated with the
+          email <strong>${email}</strong> below to claim ${itOrThem}!
+        `
+      }
+
+      if (numWhitelisted > 0) {
+
+        const [recordOrRecords, hasOrHave, itOrThem] = numWhitelisted > 1
+          ? ['Records', 'have', 'them']
+          : ['Record', 'has', 'it']
+
+        return `
+          ${numWhitelisted} Codex ${recordOrRecords} ${hasOrHave} been shared
+          with you. Log in with an Identity Provider associated with the
+          email <strong>${email}</strong> below to view ${itOrThem}!
+        `
+      }
+
+      // this is a generic message that will show if this pending user has
+      //  nothing available... which can only really happen if someone approves
+      //  an unregistered email address, then they approve someone else before
+      //  the invited user can click the link in thier email
+      //
+      // this message is a little missleading, but I suppose it's better than
+      //  showing nothing
+      return `
+        Log in with an Identity Provider associated with the email
+        <strong>${email}</strong> below to see what's waiting for you!
+      `
     },
   },
 


### PR DESCRIPTION
This is the corresponding front end PR for the associated [API PR](https://github.com/codex-protocol/private-service.codex-registry-api/pull/28). Note that this feature will be disabled on mainnet via the `supportEmailAccounts` feature flag.

## Before
![screen shot 2018-11-06 at 12 17 13 pm](https://user-images.githubusercontent.com/2358694/48088676-37c27600-e1c8-11e8-8f2b-d21a77e5f4b6.png)

## After
![screen shot 2018-11-06 at 1 29 23 pm](https://user-images.githubusercontent.com/2358694/48088685-3e50ed80-e1c8-11e8-8ef8-5abc177440fe.png)
