### PR TITLE
Various auth related bug fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -106,12 +106,16 @@ export default {
 
         return this.$store.dispatch('auth/LOGIN_FROM_CACHED_TOKEN')
           .then(() => {
-            if (!this.$route.meta.ifAuthenticatedRedirectTo) {
+            if (!this.$route.meta.ifAuthenticatedRedirect && !this.postLoginDestination) {
               return null
             }
 
             return new Promise((resolve, reject) => {
-              this.$router.replace({ name: this.$route.meta.ifAuthenticatedRedirectTo }, resolve, reject)
+              if (this.postLoginDestination) {
+                this.$router.replace({ path: this.postLoginDestination }, resolve, reject)
+              } else {
+                this.$router.replace({ name: 'collection' }, resolve, reject)
+              }
             })
           })
       })
@@ -119,7 +123,7 @@ export default {
         // Do nothing, any caught errors will be rendered on the page
       })
       .finally(() => {
-        this.$store.commit('app/SET_IS_LOADED', { isLoaded: true })
+        this.$store.commit('app/SET_IS_LOADED', true)
       })
   },
 
@@ -130,7 +134,7 @@ export default {
 
   computed: {
     ...mapGetters('auth', ['isAuthenticated']),
-    ...mapState('app', ['isLoaded']),
+    ...mapState('app', ['isLoaded', 'postLoginDestination']),
     ...mapState('auth', ['user', 'authToken']),
 
     hideSideBar() {

--- a/src/components/core/AppSideBar.vue
+++ b/src/components/core/AppSideBar.vue
@@ -63,83 +63,16 @@ export default {
 
   data() {
     return {
-      navItems: [],
       numberOfIncomingTransfers: 0,
       showFaucet: config.showFaucet,
       showCodexGallery: config.showCodexGalleryInSideBar,
     }
   },
 
-  created() {
+  mounted() {
     if (this.isAuthenticated) {
       this.updateIncomingTransfersCount()
     }
-  },
-
-  mounted() {
-    this.navItems = [
-      {
-        to: '/login',
-        condition: !this.isAuthenticated,
-        icon: iconHome,
-        text: 'Home',
-      },
-      {
-        to: '/collection',
-        condition: this.isAuthenticated,
-        icon: iconCollection,
-        text: 'Collection',
-      },
-      {
-        to: '/transfers',
-        condition: this.isAuthenticated,
-        icon: iconTransfers,
-        text: 'Transfers',
-      },
-      {
-        to: '/manage-tokens',
-        condition: this.showManageTokensPage,
-        icon: codxIcon,
-        text: 'ManageTokens',
-      },
-      {
-        to: '/faucet',
-        condition: this.showFaucet,
-        icon: faucetIcon,
-        text: 'Faucet',
-      },
-      {
-        to: '/extensions',
-        condition: this.isAuthenticated,
-        icon: starIcon,
-        text: 'Extensions',
-      },
-      {
-        to: '/galleries',
-        condition: this.showCodexGallery,
-        icon: galleryIcon,
-        text: 'Galleries',
-      },
-      {
-        to: '/settings',
-        condition: this.isAuthenticated,
-        icon: settingsIcon,
-        text: 'Settings',
-      },
-      {
-        to: '/logout',
-        action: this.logout,
-        condition: this.isAuthenticated,
-        icon: logoutIcon,
-        text: 'Logout',
-      },
-      {
-        to: '/login',
-        condition: !this.isAuthenticated,
-        icon: logoutIcon,
-        text: 'Login',
-      },
-    ]
 
     EventBus.$on('socket:codex-record:address-approved:approved', this.updateIncomingTransfersCount)
     EventBus.$on('socket:codex-record:transferred:new-owner', this.updateIncomingTransfersCount)
@@ -156,6 +89,72 @@ export default {
 
     showManageTokensPage() {
       return this.user && this.user.type === 'savvy' && config.showManageTokensPage
+    },
+
+    navItems() {
+      return [
+        {
+          to: '/login',
+          condition: !this.isAuthenticated,
+          icon: iconHome,
+          text: 'Home',
+        },
+        {
+          to: '/collection',
+          condition: this.isAuthenticated,
+          icon: iconCollection,
+          text: 'Collection',
+        },
+        {
+          to: '/transfers',
+          condition: this.isAuthenticated,
+          icon: iconTransfers,
+          text: 'Transfers',
+        },
+        {
+          to: '/manage-tokens',
+          condition: this.showManageTokensPage,
+          icon: codxIcon,
+          text: 'ManageTokens',
+        },
+        {
+          to: '/faucet',
+          condition: this.showFaucet,
+          icon: faucetIcon,
+          text: 'Faucet',
+        },
+        {
+          to: '/extensions',
+          condition: this.isAuthenticated,
+          icon: starIcon,
+          text: 'Extensions',
+        },
+        {
+          to: '/galleries',
+          condition: this.showCodexGallery,
+          icon: galleryIcon,
+          text: 'Galleries',
+        },
+        {
+          to: '/settings',
+          condition: this.isAuthenticated,
+          icon: settingsIcon,
+          text: 'Settings',
+        },
+        {
+          to: '/logout',
+          action: this.logout,
+          condition: this.isAuthenticated,
+          icon: logoutIcon,
+          text: 'Logout',
+        },
+        {
+          to: '/login',
+          condition: !this.isAuthenticated,
+          icon: logoutIcon,
+          text: 'Login',
+        },
+      ]
     },
   },
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,7 +32,7 @@ const router = new Router({
         hideSideBar: true,
         useBackgroundImage: true,
         allowUnauthenticatedUsers: true,
-        ifAuthenticatedRedirectTo: 'collection',
+        ifAuthenticatedRedirect: true,
       },
     },
     {
@@ -43,7 +43,7 @@ const router = new Router({
         hideSideBar: true,
         useBackgroundImage: true,
         allowUnauthenticatedUsers: true,
-        ifAuthenticatedRedirectTo: 'collection',
+        ifAuthenticatedRedirect: true,
       },
     },
 
@@ -131,9 +131,8 @@ if (config.showManageTokensPage) {
 }
 
 router.beforeEach((to, from, next) => {
-
-  if (to.meta.ifAuthenticatedRedirectTo && store.getters['auth/isAuthenticated']) {
-    return next({ name: to.meta.ifAuthenticatedRedirectTo })
+  if (to.meta.ifAuthenticatedRedirect && store.getters['auth/isAuthenticated']) {
+    return next({ name: 'collection' })
   }
 
   const requireAuthentication = to.matched.some((route) => {
@@ -143,9 +142,13 @@ router.beforeEach((to, from, next) => {
   // if no route was matched (i.e. a 404)
   // or if the user is trying to access an authenticated page but is unauthenticated
   // then send them to the login page
-  if (to.matched.length === 0
-    || (requireAuthentication && !store.getters['auth/isAuthenticated'])) {
-    return next({ name: 'login' })
+  if (to.matched.length === 0 || (requireAuthentication && !store.getters['auth/isAuthenticated'])) {
+    const nextRoute = { name: 'login' }
+
+    // If a route was matched but the request is unauthenticated, then cache the original destination for post-authentication
+    if (to.matched.length > 0) {
+      nextRoute.query = { destination: to.fullPath }
+    }
   }
 
   return next()

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -8,9 +8,11 @@ const logger = debug('app:store:app:actions')
 const queryParamsToHandle = {
   email: {
     mutationName: 'SET_EMAIL_ADDRESS_TO_CONFIRM',
+    clearUserState: true,
   },
   pendingUserCode: {
     mutationName: 'SET_PENDING_USER_CODE',
+    clearUserState: true,
   },
 
   // If there's a cached authToken in localstorage this will replace it with
@@ -40,10 +42,14 @@ export default {
         const param = queryParamsToHandle[key]
 
         commit(param.mutationName, query[key], param.mutationConfiguration)
+
+        if (param.clearUserState) {
+          commit('auth/CLEAR_USER_STATE', null, { root: true })
+        }
       }
     })
 
-    router.replace(rootState.route.name)
+    router.replace(rootState.route.path)
   },
 
   FETCH_VERIFIED_USERS({ commit }) {

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -14,6 +14,9 @@ const queryParamsToHandle = {
     mutationName: 'SET_PENDING_USER_CODE',
     clearUserState: true,
   },
+  destination: {
+    mutationName: 'SET_POST_LOGIN_DESTINATION',
+  },
 
   // If there's a cached authToken in localstorage this will replace it with
   //  the one from the query string

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -52,7 +52,9 @@ export default {
       }
     })
 
-    router.replace(rootState.route.path)
+    // Strip the query string by navigating to route.path (as opposed
+    //  to route.fullPath, which preserves the query string)
+    router.replace({ path: rootState.route.path })
   },
 
   FETCH_VERIFIED_USERS({ commit }) {

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -44,9 +44,15 @@ export default {
     currentState.apiErrorMessage = message
   },
 
-  SET_IS_LOADED(currentState, { isLoaded }) {
+  SET_IS_LOADED(currentState, isLoaded) {
     logMutation('SET_IS_LOADED', isLoaded)
 
     currentState.isLoaded = isLoaded
+  },
+
+  SET_POST_LOGIN_DESTINATION(currentState, destination) {
+    logMutation('SET_POST_LOGIN_DESTINATION', destination)
+
+    currentState.postLoginDestination = destination
   },
 }

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -6,5 +6,6 @@ export default () => {
     apiErrorCode: null,
     apiErrorMessage: null,
     isLoaded: false,
+    postLoginDestination: null,
   }
 }

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -234,7 +234,7 @@ export default {
         .then(() => {
           // We know this authentication happened from the Login view, so we can send the user directly to the collection page
           // We don't have to worry about the isLoading flag here since it is already set to true
-          this.$router.replace({ name: this.$route.meta.ifAuthenticatedRedirectTo || 'collection' })
+          this.$router.replace({ name: 'collection' })
         })
         .catch(() => {
           // do nothing since the LOGIN_FROM_SIGNED_DATA action will catch


### PR DESCRIPTION
Lots of minor fixes here so sending a PR to review.

- Fixes the side bar from showing the unauthenticated state after hard refreshes
- Fixes a bug where if you are logged in with one user, and try to confirm an email from the other user it would prioritize the cached auth token (similar to the auth token priority bug, but now pendingUserCode and confirmEmailAddress also have priority)
- Fixes a bug where your current location on an authenticated page would be lost after a hard refresh
- Adds basic support for the `destination` param (to fix the above). This means some emails that have plumbed `destination` will work if the user is already authenticated.