### PR TITLE
Fixes bug that caused "disabled" oauth2 login buttons to not actually be disabled

### DIFF
--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -39,10 +39,11 @@
           <!-- oauth2 login buttons -->
           <template v-if="supportEmailAccounts">
             <b-link
+              :key="index"
               :disabled="provider.isDisabled"
               :href="getOAuth2LoginUrl(provider.name)"
               @click="preventLoginIfProviderDisabled($event, provider)"
-              v-for="(provider, index) in oAuth2Providers" :key="index"
+              v-for="(provider, index) in oAuth2Providers"
             >
               <IconBase :iconName="provider.name" width="48" height="48" />
             </b-link>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -41,7 +41,7 @@
             <b-link
               :key="index"
               :disabled="provider.isDisabled"
-              :href="getOAuth2LoginUrl(provider.name)"
+              :href="getOAuth2LoginUrl(provider)"
               v-for="(provider, index) in oAuth2Providers"
             >
               <IconBase :iconName="provider.name" width="48" height="48" />
@@ -273,11 +273,11 @@ export default {
 
     getOAuth2LoginUrl(provider) {
 
-      if (!Object.keys(this.oAuth2Providers).includes(provider)) {
+      if (!this.oAuth2Providers.includes(provider)) {
         return null
       }
 
-      return `${config.apiUrl}/oauth2/login/${provider}?${this.oAuth2LoginQueryString}`
+      return `${config.apiUrl}/oauth2/login/${provider.name}?${this.oAuth2LoginQueryString}`
     },
 
     getPendingUserStats(pendingUserCode) {

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -37,7 +37,7 @@
         <div class="icons mb-3">
 
           <!-- oauth2 login buttons -->
-          <span v-if="supportEmailAccounts">
+          <template v-if="supportEmailAccounts">
             <b-link
               :disabled="provider.isDisabled"
               :href="getOAuth2LoginUrl(provider.name)"
@@ -46,7 +46,7 @@
             >
               <IconBase :iconName="provider.name" width="48" height="48" />
             </b-link>
-          </span>
+          </template>
 
           <!-- web3 login buttons -->
           <b-link @click="registerWalletProvider('metaMask')">

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -42,7 +42,6 @@
               :key="index"
               :disabled="provider.isDisabled"
               :href="getOAuth2LoginUrl(provider.name)"
-              @click="preventLoginIfProviderDisabled($event, provider)"
               v-for="(provider, index) in oAuth2Providers"
             >
               <IconBase :iconName="provider.name" width="48" height="48" />
@@ -291,10 +290,6 @@ export default {
           //  invalid
           logger(error)
         })
-    },
-
-    preventLoginIfProviderDisabled(event, provider = {}) {
-      if (provider.isDisabled === false) event.preventDefault()
     },
   },
 }


### PR DESCRIPTION
The "disabled" oauth2 login buttons [currently on Ropsten](http://ropsten.codex-viewer.com/#/) aren't actually disabled (visually or functionally.) This PR fixes that by calling `event.preventDefault()` if the provider is disabled. I wasn't sure if there was a way to like, conditionally add the `@click.prevent` property... I don't think there is, and we'd have to pass a noop or something to it anyway. Let me know if you have a better way to do that. Should the buttons just not be rendered instead?

This PR also consolidates all oauth2 login buttons into a v-for loop. Things kinda snowballed as I did the disable fix because there was so much duplicated code for each button.

## Before
![screen shot 2018-11-08 at 2 29 01 pm](https://user-images.githubusercontent.com/2358694/48225852-a982f700-e363-11e8-9003-fbb938885d8d.png)

## After
![screen shot 2018-11-08 at 2 29 09 pm](https://user-images.githubusercontent.com/2358694/48225860-adaf1480-e363-11e8-8a00-6f098387ba13.png)
