### PR TITLE
Fix a bug that shows the email field in the transfer dialog for savvy users

### DIFF
--- a/src/components/modals/ApproveTransferModal.vue
+++ b/src/components/modals/ApproveTransferModal.vue
@@ -5,7 +5,7 @@
     ok-title="Start transfer"
     cancel-variant="outline-primary"
     :ok-method="approveTransfer"
-    :on-shown="focusModal"
+    :on-shown="onShow"
     :on-clear="clearModal"
     :requires-tokens="true"
     :validate="validate"
@@ -92,15 +92,13 @@ export default {
     ...mapState('web3', ['instance']),
   },
 
-  mounted() {
-    if (this.user.type === 'savvy') {
-      this.showEthereumAddressField = true
-    }
-  },
-
   methods: {
 
-    focusModal() {
+    onShow() {
+      if (this.user.type === 'savvy') {
+        this.showEthereumAddressField = true
+      }
+
       if (this.$refs.defaultModalFocus) {
         this.$refs.defaultModalFocus.focus()
       }

--- a/src/components/modals/PrivacySettingsModal.vue
+++ b/src/components/modals/PrivacySettingsModal.vue
@@ -7,6 +7,7 @@
     v-model="modalVisible"
     v-on:ok="updateRecord"
     @hidden="onHide"
+    @shown="onShow"
   >
     <b-form-group
       label="Share Record Publicly"
@@ -167,15 +168,16 @@ export default {
     },
   },
 
-  mounted() {
-    // by default, show the ethereum address field to savvy users and the email
-    //  field to simple users
-    if (this.user.type !== 'savvy' && config.supportEmailAccounts) {
-      this.showEthereumAddressField = false
-    }
-  },
-
   methods: {
+
+    onShow() {
+      // by default, show the ethereum address field to savvy users and the email
+      //  field to simple users
+      if (this.user.type !== 'savvy' && config.supportEmailAccounts) {
+        this.showEthereumAddressField = false
+      }
+    },
+
     onHide() {
       Object.assign(this.$data, this.$options.data.apply(this))
     },


### PR DESCRIPTION
Currently on mainnet, you can see the email address field in the transfer dialog if you open the dialog more than once. The component data is being reset when the dialog closes (to clear out the fields if they've been typed in), and since the default is `false` savvy users will see the email address field every time the open the dialog after the first time, essentially breaking transfers until they refresh.