### PR TITLE
Allow isPrivate to be set upon metadata creation

### DIFF
--- a/src/components/OAuth2AppCreateRecordForm.vue
+++ b/src/components/OAuth2AppCreateRecordForm.vue
@@ -42,6 +42,21 @@
         placeholder="Upload image file"
       />
     </b-form-group>
+    <b-form-group
+      label="Share Record Publicly"
+      label-for="isPublic"
+      label-size="sm"
+    >
+      <input
+        id="isPublic"
+        type="checkbox"
+        v-model="isPublic"
+        class="toggle-checkbox"
+      />
+      <b-form-text>
+        By making this Record public, anyone can view the name, description and images.
+      </b-form-text>
+    </b-form-group>
     <b-button type="submit" variant="primary">Submit</b-button>
   </b-form>
 </template>
@@ -61,6 +76,7 @@ export default {
     return {
       name: null,
       image: null,
+      isPrivate: true,
       description: null,
     }
   },
@@ -70,6 +86,7 @@ export default {
       const formData = new FormData()
       formData.append('name', this.name)
       formData.append('mainImage', this.image)
+      formData.append('isPrivate', this.isPrivate)
       formData.append('description', this.description)
 
       axios.post('v1/client/record', formData, {
@@ -80,5 +97,16 @@ export default {
       }).then(this.showResult)
     },
   },
+
+  computed: {
+    isPublic: {
+      get: function getIsPublic() {
+        return !this.isPrivate
+      },
+      set: function setIsPublic(newValue) {
+        this.isPrivate = !newValue
+      },
+    },
+  }
 }
 </script>

--- a/src/components/modals/CreateRecordModal.vue
+++ b/src/components/modals/CreateRecordModal.vue
@@ -62,6 +62,21 @@
             v-model="description"
           />
         </b-form-group>
+        <b-form-group
+          label="Share Record Publicly"
+          label-for="isPublic"
+          label-size="sm"
+        >
+          <input
+            id="isPublic"
+            type="checkbox"
+            v-model="isPublic"
+            class="toggle-checkbox"
+          />
+          <b-form-text>
+            By making this Record public, anyone can view the name, description and images.
+          </b-form-text>
+        </b-form-group>
       </div>
     </div>
   </meta-mask-notification-modal>
@@ -94,9 +109,12 @@ export default {
       description: null,
       uploadedFile: null,
       imageStreamUri: null,
-      progressVisible: false,
-      uploadComplete: false,
       uploadSuccess: false,
+      uploadComplete: false,
+      progressVisible: false,
+      confirmMintValues: {
+        isPrivate: true,
+      },
     }
   },
 
@@ -173,6 +191,7 @@ export default {
         name: this.name,
         mainImage: this.uploadedFile,
         description: this.description || null,
+        confirmMintValues: this.confirmMintValues,
       }
 
       return Record.createMetadata(metadataToUpload)
@@ -224,6 +243,15 @@ export default {
 
       return 'danger'
     },
+
+    isPublic: {
+      get: function getIsPublic() {
+        return !this.confirmMintValues.isPrivate
+      },
+      set: function setIsPublic(newValue) {
+        this.confirmMintValues.isPrivate = !newValue
+      },
+    },
   },
 }
 </script>
@@ -232,9 +260,6 @@ export default {
 .flex-container
   display: flex
   flex-direction: column
-
-  input
-    width: 100%
 
   @media screen and (min-width: $breakpoint-sm)
     flex-direction: row

--- a/src/components/modals/PrivacySettingsModal.vue
+++ b/src/components/modals/PrivacySettingsModal.vue
@@ -158,6 +158,8 @@ export default {
     ...mapState('auth', ['user']),
     ...mapState('web3', ['instance']),
 
+    // it's more verbose to do this, but it makes passing isPrivate much more
+    //  intuitive than isPublic
     isPublic: {
       get: function getIsPublic() {
         return !this.isPrivate


### PR DESCRIPTION
This PR allows users to set `isPrivate` in the `CreateRecordModal`. [See the associated backend PR here.](https://github.com/codex-protocol/private-service.codex-registry-api/pull/37)

![screen shot 2018-11-19 at 3 14 43 pm](https://user-images.githubusercontent.com/2358694/48735389-deb60180-ec0d-11e8-8985-b02e0d499daf.png)