### PR TITLE
Replace "formatTokenAmount" helper with "formatCodxBlanace" filter

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -57,6 +57,7 @@ import ToastContainer from './components/util/ToastContainer'
 import PartyModeActivator from './directives/PartyModeActivator'
 
 import './util/analytics'
+import './filters/format-codx-balance'
 
 export default {
   name: 'App',

--- a/src/components/CODXBalanceControl.vue
+++ b/src/components/CODXBalanceControl.vue
@@ -2,7 +2,7 @@
   <div class="codx-balance-container">
     <div>
       <h4>Credit Balance</h4>
-      <div>{{ formattedTokenBalance }}</div>
+      <div>{{ user.codxBalance | formatCODXBalance }}</div>
     </div>
     <!-- <img id="codx-balance-info" src="../assets/icons/info.svg">
 
@@ -26,8 +26,6 @@
 import is from 'is_js'
 import { mapState } from 'vuex'
 
-import formatTokenAmount from '../util/formatTokenAmount'
-
 export default {
   name: 'CODXBalanceControl',
 
@@ -36,10 +34,6 @@ export default {
 
     popoverPlacement() {
       return is.mobile() ? 'top' : 'right'
-    },
-
-    formattedTokenBalance() {
-      return `${formatTokenAmount(this.user.codxBalance)} CODX`
     },
   },
 }

--- a/src/components/PersonalStakesTable.vue
+++ b/src/components/PersonalStakesTable.vue
@@ -9,7 +9,7 @@
         :style="{ order: index }"
         :key="'actualAmount' + index"
       >
-        {{ formatTokenAmount(property) }} CODX
+        {{ property | formatCODXBalance }}
       </div>
 
       <div class="table-header addresses">Staked for</div>
@@ -35,7 +35,6 @@
 </template>
 
 <script>
-import formatTokenAmount from '../util/formatTokenAmount'
 import DisplayName from './util/DisplayName'
 
 export default {
@@ -43,11 +42,6 @@ export default {
   props: ['personalStakes'],
   components: {
     DisplayName,
-  },
-  methods: {
-    formatTokenAmount(rawAmount) {
-      return formatTokenAmount(rawAmount)
-    },
   },
 }
 </script>

--- a/src/components/cards/FaucetMarketingCard.vue
+++ b/src/components/cards/FaucetMarketingCard.vue
@@ -14,7 +14,7 @@
           <li :class="{ 'completed': currentStep >= 2 }">Get CODX from the faucet</li>
           <li :class="{ 'completed': currentStep >= 3 }">Approve the registry contract</li>
         </ul>
-        <p>Your balance: {{ formattedBalance }} CODX</p>
+        <p>Your balance: {{ user.codxBalance | formatCODXBalance }}</p>
       </div>
       <b-button
         variant="primary"
@@ -43,10 +43,8 @@
 import { mapState } from 'vuex'
 import BigNumber from 'bignumber.js'
 
-import formatTokenAmount from '../../util/formatTokenAmount'
-
-import ApproveContractModal from './../modals/ApproveContractModal'
 import FaucetModal from './../modals/FaucetModal'
+import ApproveContractModal from './../modals/ApproveContractModal'
 
 export default {
   name: 'FaucetMarketingCard',
@@ -65,10 +63,6 @@ export default {
 
     done() {
       return this.currentStep === this.numSteps
-    },
-
-    formattedBalance() {
-      return formatTokenAmount(this.user.codxBalance)
     },
 
     currentStep() {
@@ -114,9 +108,6 @@ export default {
     },
     hide() {
       this.$store.dispatch('auth/HIDE_SETUP')
-    },
-    formatTokenAmount(rawAmount) {
-      return formatTokenAmount(rawAmount)
     },
   },
 }

--- a/src/filters/format-codx-balance.js
+++ b/src/filters/format-codx-balance.js
@@ -1,0 +1,18 @@
+import Vue from 'vue'
+import BigNumber from 'bignumber.js'
+
+export default Vue.filter('formatCODXBalance', (value, numDecimals = 3, showCODXLabel = true) => {
+
+  const reducedValue = new BigNumber(value || 0).div('1e18')
+  const fixedValue = reducedValue.toFixed(numDecimals)
+
+  // only show the toFixed() value if it's not all zeros after the decimal
+  const codxAmount = /\.0*$/.test(fixedValue)
+    ? reducedValue.toString()
+    : fixedValue
+
+  return showCODXLabel
+    ? `${codxAmount} CODX`
+    : codxAmount
+
+})

--- a/src/util/formatTokenAmount.js
+++ b/src/util/formatTokenAmount.js
@@ -1,5 +1,0 @@
-import BigNumber from 'bignumber.js'
-
-export default (rawAmount) => {
-  return new BigNumber(rawAmount).div('1e18').toFixed(3)
-}

--- a/src/util/socket/eventToastHandlers.js
+++ b/src/util/socket/eventToastHandlers.js
@@ -1,6 +1,6 @@
 import router from '../../router'
 import EventBus from '../eventBus'
-import formatTokenAmount from '../formatTokenAmount'
+import formatCODXBalance from '../../filters/format-codx-balance'
 
 // this is here as a wrapper / convenience method so we don't have to repeat a
 //  bunch of stuff in the handlers below
@@ -77,7 +77,7 @@ export default {
   },
 
   'codex-coin:transferred': (value) => {
-    showToast(`You have successfully recieved ${formatTokenAmount(value)} CODX from the faucet.`)
+    showToast(`You have successfully recieved ${formatCODXBalance(value)} CODX from the faucet.`)
   },
 
   'codex-coin:registry-contract-approved': (value) => {

--- a/src/views/FaucetView.vue
+++ b/src/views/FaucetView.vue
@@ -36,7 +36,7 @@
                 Get more CODX
               </b-button>
 
-              <p>Your balance: {{ formattedBalance }} CODX</p>
+              <p>Your balance: {{ user.codxBalance | formatCODXBalance }}</p>
               <p v-if="!user.canRequestFaucetDrip">
                 <strong>You'll be able to request more CODX in {{ nextRequestIn }}</strong>
               </p>
@@ -67,7 +67,6 @@
 import { mapState } from 'vuex'
 
 import { timeSince } from '../util/dateHelpers'
-import formatTokenAmount from '../util/formatTokenAmount'
 
 import AppHeader from '../components/core/AppHeader'
 import FaucetModal from '../components/modals/FaucetModal'
@@ -85,10 +84,6 @@ export default {
   computed: {
     ...mapState('auth', ['registryContractApproved', 'user']),
     ...mapState('web3', ['recordContract']),
-
-    formattedBalance() {
-      return formatTokenAmount(this.user.codxBalance)
-    },
 
     nextRequestIn() {
       const now = Date.now()


### PR DESCRIPTION
Trying to reduce a lot of duplicated code with a Vue filter, since the `formatTokenAmount()` is essentially the exact use case for a filter. This lets us remove all the "proxying" for the helper inside every component that uses it.

The new filter also truncates digits after the decimal place if they're all zero (i.e. `100.000 CODX` is now `100 CODX`.)