### PR TITLE
Defer app initialization until after bootstrap data is recieved

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -168,6 +168,7 @@ export default {
 
           return this.$store.dispatch('auth/LOGIN_FROM_CACHED_TOKEN')
             .then(() => {
+
               // Start fetching app & user data that is dependent on authentication
               // No need to block on these async actions
               this.$store.dispatch('records/FETCH_USER_DATA')
@@ -187,7 +188,7 @@ export default {
             })
         })
         .catch(() => {
-        // Do nothing, any caught errors will be rendered on the page
+          // Do nothing, any caught errors will be rendered on the page
         })
         .finally(() => {
           this.$store.commit('app/SET_IS_LOADED', true)

--- a/src/App.vue
+++ b/src/App.vue
@@ -91,8 +91,6 @@ export default {
   created() {
     this.initializeApi()
 
-    this.$store.dispatch('app/FETCH_BOOTSTRAP_DATA')
-
     EventBus.$on('socket:codex-coin:savvy-spend', this.spendCODX)
     EventBus.$on('socket:codex-coin:transferred', this.refundCODX)
     EventBus.$on('socket:codex-coin:registry-contract-approved', this.fetchApprovalStatuses)
@@ -107,7 +105,10 @@ export default {
   },
 
   mounted() {
-    this.initializeApp()
+    this.$store.dispatch('app/FETCH_BOOTSTRAP_DATA')
+      .finally(() => {
+        this.initializeApp()
+      })
   },
 
   beforeDestroy() {


### PR DESCRIPTION
Now that I think about it, this may not be the best course of action. It's _probably_ okay, but it does defer the page from showing anything until that first API call is made, and the bootstrap data is really only necessary for simple users... I dunno, open to other suggestions