### PR TITLE
Resets Vuex states on logout

### DIFF
--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -48,7 +48,7 @@ export default {
         commit(param.mutationName, query[key], param.mutationConfiguration)
 
         if (param.clearUserState) {
-          commit('auth/CLEAR_USER_STATE', null, { root: true })
+          commit('auth/RESET_STATE', null, { root: true })
         }
       }
     })

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -1,11 +1,19 @@
 import debug from 'debug'
 
+import getInitialState from './state'
+
 const logger = debug('app:store:app:mutations')
 const logMutation = (mutationName, ...args) => {
   logger(`${mutationName} mutation being executed`, ...args)
 }
 
 export default {
+
+  RESET_STATE(currentState) {
+    logMutation('app/RESET_STATE')
+    Object.assign(currentState, getInitialState(), { isLoaded: currentState.isLoaded })
+  },
+
   SET_VERIFIED_USERS(currentState, users) {
     logMutation('SET_VERIFIED_USERS', users)
 

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -1,19 +1,11 @@
 import debug from 'debug'
 
-import getInitialState from './state'
-
 const logger = debug('app:store:app:mutations')
 const logMutation = (mutationName, ...args) => {
   logger(`${mutationName} mutation being executed`, ...args)
 }
 
 export default {
-
-  RESET_STATE(currentState) {
-    logMutation('app/RESET_STATE')
-    Object.assign(currentState, getInitialState(), { isLoaded: currentState.isLoaded })
-  },
-
   SET_VERIFIED_USERS(currentState, users) {
     logMutation('SET_VERIFIED_USERS', users)
 

--- a/src/store/modules/auth/actions.js
+++ b/src/store/modules/auth/actions.js
@@ -213,7 +213,9 @@ export default {
   LOGOUT_USER({ commit }) {
     logger('LOGOUT_USER action being executed')
 
-    commit('CLEAR_USER_STATE')
+    commit('app/RESET_STATE', null, { root: true })
+    commit('auth/RESET_STATE', null, { root: true })
+    commit('records/RESET_STATE', null, { root: true })
 
     // if this is an unauthenticated route, clear their auth token (i.e. log
     //  the user out), but do not redirect them to the login page

--- a/src/store/modules/auth/actions.js
+++ b/src/store/modules/auth/actions.js
@@ -213,7 +213,6 @@ export default {
   LOGOUT_USER({ commit }) {
     logger('LOGOUT_USER action being executed')
 
-    commit('app/RESET_STATE', null, { root: true })
     commit('auth/RESET_STATE', null, { root: true })
     commit('records/RESET_STATE', null, { root: true })
 

--- a/src/store/modules/auth/mutations.js
+++ b/src/store/modules/auth/mutations.js
@@ -36,8 +36,8 @@ export default {
     currentState.user = Object.assign({}, currentState.user, newProperties)
   },
 
-  CLEAR_USER_STATE(currentState) {
-    logMutation('CLEAR_USER_STATE')
+  RESET_STATE(currentState) {
+    logMutation('auth/RESET_STATE')
 
     SocketService.disconnect()
     window.localStorage.removeItem('authToken')

--- a/src/store/modules/records/mutations.js
+++ b/src/store/modules/records/mutations.js
@@ -1,5 +1,7 @@
-import debug from 'debug'
 import Vue from 'vue'
+import debug from 'debug'
+
+import getInitialState from './state'
 
 const logger = debug('app:store:records:mutations')
 const logMutation = (mutationName, ...args) => {
@@ -7,6 +9,12 @@ const logMutation = (mutationName, ...args) => {
 }
 
 export default {
+
+  RESET_STATE(currentState) {
+    logMutation('records/RESET_STATE')
+    Object.assign(currentState, getInitialState())
+  },
+
   SET_RECORDS(currentState, { listName, records }) {
     logMutation('SET_RECORDS', listName, records)
 


### PR DESCRIPTION
Currently, the Vuex states are not cleared on logout. This has the effect of persisting user data in-memory, which could potentially be problematic. For example:

1. Login as a user with records.
2. Log out
3. Manually change your url back to `/#/collection`
4. You'll still see all the cached data

This PR adds a `RESET_STATE` mutator to all Vuex modules that simple reverts the state back to it's initial value, and is called on logout. Resetting the whole state seems a little brittle, but it seems to work from what I can tell.